### PR TITLE
Removing redundant `scopes` field from `authorization_servers`

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -546,6 +546,7 @@ authorization_servers
 
 > OPTIONAL. An array of supported authorization servers and the scopes they support. Each element of the array is a Authorization Server Descriptor JSON object defined in the section {{authz-server-descriptor}} below. If the `supported_scopes` member is present in the metadata, then the `authorization_servers` MUST also be present, and it MUST provide a server location for every supported scope. The list of servers MUST satisfy all the scopes listed in `supported_scope` section.
 
+
 TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
 {{RFC8414}}. This would allow other specs to add to the metadata.
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -544,17 +544,13 @@ supported_scopes
 
 authorization_servers
 
-> OPTIONAL. An array of supported authorization servers and the scopes they support. Each element of the array is a Authorization Server Descriptor JSON object defined in the section {{authz-server-descriptor}} below. If the `supported_scopes` member is present in the metadata, then the `authorization_servers` MUST also be present, and it MUST provide a server location for every supported scope.
+> OPTIONAL. An array of supported authorization servers and the scopes they support. Each element of the array is a Authorization Server Descriptor JSON object defined in the section {{authz-server-descriptor}} below. If the `supported_scopes` member is present in the metadata, then the `authorization_servers` MUST also be present, and it MUST provide a server location for every supported scope. The list of servers MUST satisfy all the scopes listed in `supported_scope` section.
 
 TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
 {{RFC8414}}. This would allow other specs to add to the metadata.
 
 ### Authorization Server Descriptor {#authz-server-descriptor}
 An Authorization Server Descriptor is a JSON object that has two keys:
-
-scopes
-
-> REQUIRED. An array of scope names supported by the authorization server
 
 servers
 
@@ -564,7 +560,6 @@ The following is a non-normative example of an Authorization Server Descriptor
 
 ~~~ json
 {
-    "scopes" : ["scope1", "scope2"],
     "servers": [
         "https://server1.example/base/url",
         "https://server2.example/base/url",


### PR DESCRIPTION
Removing redundant scopes field from authorization_servers

scopes in `authorization_servers` is not adding any value, but may cause confusion.

Added a statement indicating "Authorization_servers should satisfy all the scopes listed in `supported_scopes`"