### PR TITLE
Clarification of events_delivered

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -822,10 +822,12 @@ events_requested
 
 events_delivered
 
-> **Transmitter-Supplied**, An array of URIs which is the intersection of
-  "events_supported" and "events_requested". These events MAY be delivered over
-  the Event Stream. A Receiver MUST rely on the values received in this field
-  to understand which event types it can expect from the Transmitter.
+> **Transmitter-Supplied**, An array of URIs identifying the set of events
+  which is the intersection of "events_supported" and "events_requested". A 
+  transmitter MAY decide to deliver only a subset of events represented by 
+  this intersection. These events MAY be delivered over the Event Stream. A 
+  Receiver MUST rely on the values received in this field to understand which 
+  event types it can expect from the Transmitter.
 
 delivery
 


### PR DESCRIPTION
Clarification of events_delivered from the past calls 

The transmitter may reserve rights to deliver events on certain occasions such as (but not limited to) -
1. Receiver has not paid for SKU that the event is part of, 
2. Receiver is not in the desired jurisdiction/compliance environment to receive the event

Discussion contexts -
1. 4/4 https://hackmd.io/@oidf-wg-sse/wg-meeting-20230404 
3. 8/29 https://hackmd.io/nW6HWJ4WQfaX2ZAnm758Uw