### PR TITLE
Issue 163 - add field to configuration data indicating expected subject behavior for new streams

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -604,8 +604,9 @@ authorization_schemes
 
 default_subjects
 
-> OPTIONAL. A string indicating the default behavior of newly created streams. The value
-  MUST be either "ALL" or "NONE". If not provided, the default value is "NONE".
+> OPTIONAL. A string indicating the default behavior of newly created streams. If present,
+  the value MUST be either "ALL" or "NONE". If not provided, the Transmitter behavior in
+  this regard is unspecified.
 >  - "ALL" indicates that events for all subjects are transmitted by default. The Receiver
     MAY remove subjects from the stream via the `remove_subject_endpoint`, causing only
     events for those subjects to _not_ be transmitted. The Receiver MAY re-add any

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -593,10 +593,9 @@ default_subjects
   the value MUST be either "ALL" or "NONE". If not provided, the Transmitter behavior in
   this regard is unspecified.
 >  - "ALL" indicates that any subjects that are appropriate for the stream are added to
-    the stream by default. The Receiver
-    MAY remove subjects from the stream via the `remove_subject_endpoint`, causing only
-    events for those subjects to _not_ be transmitted. The Receiver MAY re-add any
-    subjects removed this way via the `add_subject_endpoint`.
+    the stream by default. The Receiver MAY remove subjects from the stream via the
+    `remove_subject_endpoint`, causing events for those subjects to _not_ be transmitted.
+    The Receiver MAY re-add any subjects removed this way via the `add_subject_endpoint`.
 >  - "NONE" indicates that no subjects are added by default. The Receiver MAY add subjects
     to the stream via the `add_subject_endpoint`, causing only events for those subjects
     to be transmitted. The Receiver MAY remove subjects added this way via the
@@ -2173,7 +2172,7 @@ multiple Receivers would lead to unintended data disclosure.
 {: title="Example: SET with array 'aud' claim" #figarrayaud}
 
 ### The "txn" claim {#txn-claim}
-Transmitters SHOULD set the "txn" claim value in Security Event Tokens (SETs). If the value is present, it MUST be unique to the underlying event that caused the Transmitter to generate the Security Event Token (SET). The Transmitter, however, may use the same value in the "txn" claim across different Security Events Tokens (SETs), such as session revoked and credential change, to indicate that the SETs originated from the same underlying cause or reason. 
+Transmitters SHOULD set the "txn" claim value in Security Event Tokens (SETs). If the value is present, it MUST be unique to the underlying event that caused the Transmitter to generate the Security Event Token (SET). The Transmitter, however, may use the same value in the "txn" claim across different Security Events Tokens (SETs), such as session revoked and credential change, to indicate that the SETs originated from the same underlying cause or reason.
 
 ### The "events" claim {#events-claim}
 The "events" claim SHOULD contain only one event. Multiple event type URIs are

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -607,7 +607,8 @@ default_subjects
 > OPTIONAL. A string indicating the default behavior of newly created streams. If present,
   the value MUST be either "ALL" or "NONE". If not provided, the Transmitter behavior in
   this regard is unspecified.
->  - "ALL" indicates that events for all subjects are transmitted by default. The Receiver
+>  - "ALL" indicates that any subjects that are appropriate for the stream are added to
+    the stream by default. The Receiver
     MAY remove subjects from the stream via the `remove_subject_endpoint`, causing only
     events for those subjects to _not_ be transmitted. The Receiver MAY re-add any
     subjects removed this way via the `add_subject_endpoint`.

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -602,6 +602,18 @@ authorization_schemes
   security considerations, make the authorization_schemes attribute
   publicly accessible without prior authentication.
 
+default_subjects
+
+> OPTIONAL. A string indicating the default behavior of newly created streams. The value
+  MUST be either "ALL" or "NONE". If not provided, the default value is "NONE".
+>  - "ALL" indicates that events for all subjects are transmitted by default. The Receiver
+    MAY remove subjects from the stream via the `remove_subject_endpoint`, causing only
+    events for those subjects to _not_ be transmitted. The Receiver MAY re-add any
+    subjects removed this way via the `add_subject_endpoint`.
+>  - "NONE" indicates that no subjects are added by default. The Receiver MAY add subjects
+    to the stream via the `add_subject_endpoint`, causing only events for those subjects
+    to be transmitted. The Receiver MAY remove subjects added this way via the
+    `remove_subject_endpoint`.
 
 TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
 {{RFC8414}}. This would allow other specs to add to the metadata.

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -745,7 +745,8 @@ Content-Type: application/json
       {
         "spec_urn": "urn:ietf:rfc:8705"
       }
-    ]
+    ],
+  "default_subjects": "NONE"
 }
 ~~~
 {: #figdiscoveryresponse title="Example: Transmitter Configuration Response"}


### PR DESCRIPTION
Addresses issue #163 by adding an optional field, `default_subjects` to the Transmitter Configuration data. The field is a string which can be either `ALL` or `NONE` and defaults to `NONE` if not provided. The interpretation of this field is as follows:

- `ALL`: All subjects are added by default. Calling `remove_subject_endpoint` acts like a filter, blocking the transmission of only the specified subjects. Calling `add_subject_endpoint` can effectively clear any filters set by `remove_subject_endpoint` but otherwise does nothing.
- `NONE`: No subjects are added by default. Calling `add_subject_endpoint` adds a subject to the stream. Calling `remove_subject_endpoint` can remove a previously added subject, but otherwise does nothing.