### PR TITLE
Added language requiring authorization of stream management API

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -96,9 +96,11 @@ normative:
     title: OpenID Connect Core 1.0 - ID Token
   OASIS.saml-core-2.0-os:
   RFC2119:
+  RFC2818:
   RFC6749:
   RFC6750:
   RFC7159:
+  RFC7235:
   RFC7517:
   RFC7519:
   RFC8174:
@@ -761,6 +763,14 @@ This section defines an HTTP API to be implemented by Event Transmitters
 which can be used by Event Receivers to create and delete one or more Event Streams.
 The API can also be used to query and update the Event Stream's configuration and status,
 add and remove Subjects, and trigger verification for those streams.
+
+Unless there exists some other method of establishing trust between a Transmitter and
+Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC2818}}
+and standard HTTP authentication and authorization schemes, as per {{RFC7235}}.
+The authorization MUST scope a Receiver to specific stream IDs, such that only that
+Receiver is able to access or modify the details of the Event Stream.
+The Transmitter MAY describe the available authorization schemes in the Transmitter
+Configuration metadata, as described in {{discovery-meta}}.
 
 ~~~
 +------------+                +------------+

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -96,11 +96,9 @@ normative:
     title: OpenID Connect Core 1.0 - ID Token
   OASIS.saml-core-2.0-os:
   RFC2119:
-  RFC2818:
   RFC6749:
   RFC6750:
   RFC7159:
-  RFC7235:
   RFC7517:
   RFC7519:
   RFC8174:
@@ -765,9 +763,9 @@ The API can also be used to query and update the Event Stream's configuration an
 add and remove Subjects, and trigger verification for those streams.
 
 Unless there exists some other method of establishing trust between a Transmitter and
-Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC2818}}
-and standard HTTP authentication and authorization schemes, as per {{RFC7235}}.
-The authorization MUST associate a Receiver with one or more stream IDs, such that only
+Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC9110}}
+and standard HTTP authentication and authorization schemes, as per {{RFC9110}}.
+This authorization MUST associate a Receiver with one or more stream IDs, such that only
 authorized Receivers are able to access or modify the details of the associated Event Streams.
 
 ~~~

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -769,8 +769,6 @@ Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC2818}}
 and standard HTTP authentication and authorization schemes, as per {{RFC7235}}.
 The authorization MUST scope a Receiver to specific stream IDs, such that only that
 Receiver is able to access or modify the details of the Event Stream.
-The Transmitter MAY describe the available authorization schemes in the Transmitter
-Configuration metadata, as described in {{discovery-meta}}.
 
 ~~~
 +------------+                +------------+

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -767,8 +767,8 @@ add and remove Subjects, and trigger verification for those streams.
 Unless there exists some other method of establishing trust between a Transmitter and
 Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC2818}}
 and standard HTTP authentication and authorization schemes, as per {{RFC7235}}.
-The authorization MUST scope a Receiver to specific stream IDs, such that only that
-Receiver is able to access or modify the details of the Event Stream.
+The authorization MUST associate a Receiver with one or more stream IDs, such that only
+authorized Receivers are able to access or modify the details of the associated Event Streams.
 
 ~~~
 +------------+                +------------+

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -563,7 +563,7 @@ jwks_uri
 > OPTIONAL. URL of the Transmitter's JSON Web Key Set {{RFC7517}} document.
   This contains the signing key(s) the Receiver uses to validate signatures from
   the Transmitter. This value MUST be specified if the Transmitter intends to
-  generate signed JWTs.
+  generate signed JWTs. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 delivery_methods_supported
 
@@ -571,23 +571,23 @@ delivery_methods_supported
 
 configuration_endpoint
 
-> OPTIONAL. The URL of the Configuration Endpoint.
+> OPTIONAL. The URL of the Configuration Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 status_endpoint
 
-> OPTIONAL. The URL of the Status Endpoint.
+> OPTIONAL. The URL of the Status Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 add_subject_endpoint
 
-> OPTIONAL. The URL of the Add Subject Endpoint.
+> OPTIONAL. The URL of the Add Subject Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 remove_subject_endpoint
 
-> OPTIONAL. The URL of the Remove Subject Endpoint.
+> OPTIONAL. The URL of the Remove Subject Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 verification_endpoint
 
-> OPTIONAL. The URL of the Verification Endpoint.
+> OPTIONAL. The URL of the Verification Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
 
 critical_subject_members
 
@@ -763,10 +763,11 @@ The API can also be used to query and update the Event Stream's configuration an
 add and remove Subjects, and trigger verification for those streams.
 
 Unless there exists some other method of establishing trust between a Transmitter and
-Receiver, all Stream Management API endpoints MUST use HTTP over TLS {{RFC9110}}
-and standard HTTP authentication and authorization schemes, as per {{RFC9110}}.
-This authorization MUST associate a Receiver with one or more stream IDs, such that only
-authorized Receivers are able to access or modify the details of the associated Event Streams.
+Receiver, all Stream Management API endpoints MUST use standard HTTP
+authentication and authorization schemes, as per {{RFC9110}}.
+This authorization MUST associate a Receiver with one or more stream IDs and "aud" values,
+such that only authorized Receivers are able to access or modify the details of the
+associated Event Streams.
 
 ~~~
 +------------+                +------------+

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -107,6 +107,7 @@ normative:
   RFC8615:
   RFC8935:
   RFC8936:
+  RFC9110:
   RFC9493:
   CAEP:
     author:


### PR DESCRIPTION
To address the attacks proposed in #161 and #160, this PR adda a paragraph indicating that all Stream Management API endpoints must use authorization that associates stream IDs with a specific Receiver, unless some other method of trust is established.