### PR TITLE
Add sentence suggesting that Issuer information should be validated by the Receiver

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -632,7 +632,7 @@ Transmitter.
 
 Using the Issuer URL as documented by the Transmitter, the Transmitter Configuration
 Metadata can be retrieved. Receivers SHOULD ensure that the Issuer URL comes from a
-trusted source and uses the https scheme.
+trusted source and uses the `https` scheme.
 
 Transmitters supporting Discovery MUST make a JSON document available at the
 path formed by inserting the string "/.well-known/ssf-configuration" into the

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -631,7 +631,8 @@ Transmitter.
 ## Obtaining Transmitter Configuration Metadata
 
 Using the Issuer URL as documented by the Transmitter, the Transmitter Configuration
-Metadata can be retrieved.
+Metadata can be retrieved. Receivers SHOULD ensure that the Issuer URL comes from a
+trusted source and uses the https scheme.
 
 Transmitters supporting Discovery MUST make a JSON document available at the
 path formed by inserting the string "/.well-known/ssf-configuration" into the


### PR DESCRIPTION
There are three problems mentioned in Issue #166:

1) We need to add language that suggests the Receiver validate the Issuer value before doing discovery. This PR addresses that.

2) We need to add TLS restriction to the stream management endpoints. PR #173 addresses that.

3) We need to restrict delivery methods to only secure options. That is already done by the fact that the Stream Configuration metadata's `delivery.method` field can only be one of `push` or `poll`.