### PR TITLE
Specify one event per "events" claim of SET for Interoperability Profile

### DIFF
--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -179,8 +179,7 @@ All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bi
 ## Security Event Token
 
 ### The "events" claim
-The "events" claim of the SET MUST contain only one event. If more than one event is provided in the "events" claim, only the first event will be respected. All other events
-will be ignored.
+The "events" claim of the SET MUST contain only one event.
 
 # Use Cases
 Implementations MAY choose to support one or more of the following use-cases in order to be considered interoperable implementations

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -176,6 +176,12 @@ Receivers MUST be prepared to accept events with any of the subject identifier f
 ## Event Signatures
 All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bit keys.
 
+## Security Event Token
+
+### The "events" claim
+The "events" claim of the SET MUST contain only one event. If more than one event is provided in the "events" claim, only the first event will be respected. All other events
+will be ignored.
+
 # Use Cases
 Implementations MAY choose to support one or more of the following use-cases in order to be considered interoperable implementations
 


### PR DESCRIPTION
As discussed in WG meeting from 2024-05-14, specify that only one event is allowed in the interoperability profile.

Fixes Issue #167 