### PR TITLE
Removed cause-time from RISC example

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -2037,8 +2037,7 @@ specific to the event type.
   },
   "events": {
     "https://schemas.openid.net/secevent/risc/event-type/account-disabled": {
-      "reason": "hijacking",
-      "cause-time": 1508012752
+      "reason": "hijacking"
     }
   }
 }


### PR DESCRIPTION
`cause-time` is not a known field of the RISC `account-disabled` event. Removing it.