### PR TITLE
Fix CAEP Session Established event example

### DIFF
--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -769,7 +769,7 @@ The following is a non-normative example of the `session-established` event type
           "ips": ["192.168.1.12", "10.1.1.1"],
           "fp_ua": "abb0b6e7da81a42233f8f2b1a8ddb1b9a4c81611",
           "acr": "AAL2",
-          "amr": "otp",
+          "amr": ["otp"],
           "event_timestamp": 1615304991643
         }
     }


### PR DESCRIPTION
On a Session Established event, `amr` is an optional claim whose value is an array of strings. However, the example includes a string instead.

This PR fixes the typo in the example. 