### PR TITLE
Update out of date links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSF: Shared Signals Framework #
 
-The goal of the [Shared Signals](http://openid.net/wg/sharedsignals/) Working Group is to enable the sharing of security events, state changes, and other signals between related and/or dependent systems in order to:
+The goal of the [Shared Signals](https://openid.net/wg/sharedsignals/) Working Group is to enable the sharing of security events, state changes, and other signals between related and/or dependent systems in order to:
 
 * Manage access to resources and enforce access control restrictions across distributed services operating in a dynamic environment.
 * Prevent malicious actors from leveraging compromises of accounts, devices, services, endpoints, or other principals or resources to gain unauthorized access to additional systems or resources.

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -31,7 +31,7 @@ normative:
   RFC4001: # Textual Conventions for Internet Network Addresses
 
   ISO-IEC-29115:
-    target: http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=45138
+    target: https://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=45138
     title: "ISO/IEC 29115:2013 -- Information technology - Security techniques - Entity authentication assurance framework"
     author:
       -
@@ -94,7 +94,7 @@ normative:
     - ins: C. Mortimore
       name: Chuck Mortimore
     date: November 2014
-    target: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
+    target: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
     title: OpenID Connect Core 1.0 - ID Token
   RFC2119:
   RFC8174:
@@ -103,13 +103,13 @@ normative:
   RFC6711:
   RFC8176:
   SSF:
-    target: http://openid.net/specs/openid-sse-framework-1_0.html
+    target: https://openid.net/specs/openid-sharedsignals-framework-1_0.html
     title: OpenID Shared Signals and Events Framework Specification 1.0
     author:
       -
         ins: A. Tulshibagwale
         name: Atul Tulshibagwale
-        org: Google
+        org: SGNL
       -
         ins: T. Cappalli
         name: Tim Cappalli
@@ -126,7 +126,11 @@ normative:
         ins: John Bradley
         name: John Bradley
         org: Yubico
-    date: 2021-05
+      -
+        ins: S. Miel
+        name: Shayne Miel
+        org: Cisco
+    date: 2024-06-25
   WebAuthn:
     target: https://www.w3.org/TR/webauthn/
     title: "Web Authentication: An API for accessing Public Key Credentials Level 2"

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -87,6 +87,13 @@ normative:
       - ins: D. Fett
       - ins: D. Tonge
       - ins: J. Heenan
+  OPRM:
+    target: https://www.ietf.org/archive/id/draft-ietf-oauth-resource-metadata-03.html
+    title: OAuth 2.0 Protected Resource Metadata
+    author:
+      -ins: M.B. Jones
+      -ins: P. Hunt
+      -ins: A. Parecki
 
 
 --- abstract
@@ -218,9 +225,9 @@ All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bi
 ### OAuth Scopes
 Depending on the features supported by the OAuth service and the SSF APIs, the client SHALL discover the OAuth scopes as follows:
 
-1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{RFC8414}} then the client MUST obtain the required scopes by using it.
+1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{OPRM}} then the client MUST obtain the required scopes by using it.
 
-2. If the Resource Server does not support {{RFC8414}}, then the following scopes MUST be supported -
+2. If the Resource Server does not support {{OPRM}}, then the following scopes MUST be supported -
    - An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of `ssf`
    - All the SSF stream configuration management API operations MUST accept `ssf.manage` scope
    - All the SSF stream configuration Read API operations MUST accept `ssf.read` scope
@@ -233,7 +240,7 @@ Depending on the features supported by the OAuth service and the SSF APIs, the c
 * MUST verify the validity, integrity, expiration and revocation status of access tokens
 * MUST verify that the authorization represented by the access token is sufficient for the requested resource access.
 * If the access token is not sufficient for the requested action, the Resource server MUST return errors as per section 3.1 of [RFC6750]{{RFC6750}}
-* MAY publish the {{RFC8414}} to describe the metadata needed to interact with the protected resource.
+* MAY publish the {{OPRM}} to describe the metadata needed to interact with the protected resource.
 
 ## Security Event Token
 

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -63,7 +63,7 @@ normative:
         org: Cisco
 
   CAEP:
-    target: https://openid.net/specs/openid-caep-specification-1_0.html
+    target: https://openid.net/specs/openid-caep-1_0.html
     title: OpenID Continuous Access Evaluation Profile 1.0
     author:
       -
@@ -87,13 +87,6 @@ normative:
       - ins: D. Fett
       - ins: D. Tonge
       - ins: J. Heenan
-  OPRM:
-    target: https://www.ietf.org/archive/id/draft-ietf-oauth-resource-metadata-03.html
-    title: OAuth 2.0 Protected Resource Metadata
-    author:
-      -ins: M.B. Jones
-      -ins: P. Hunt
-      -ins: A. Parecki
 
 
 --- abstract
@@ -225,9 +218,9 @@ All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bi
 ### OAuth Scopes
 Depending on the features supported by the OAuth service and the SSF APIs, the client SHALL discover the OAuth scopes as follows:
 
-1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{OPRM}} then the client MUST obtain the required scopes by using it.
+1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{RFC8414}} then the client MUST obtain the required scopes by using it.
 
-2. If the Resource Server does not support {{OPRM}}, then the following scopes MUST be supported -
+2. If the Resource Server does not support {{RFC8414}}, then the following scopes MUST be supported -
    - An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of `ssf`
    - All the SSF stream configuration management API operations MUST accept `ssf.manage` scope
    - All the SSF stream configuration Read API operations MUST accept `ssf.read` scope
@@ -240,7 +233,7 @@ Depending on the features supported by the OAuth service and the SSF APIs, the c
 * MUST verify the validity, integrity, expiration and revocation status of access tokens
 * MUST verify that the authorization represented by the access token is sufficient for the requested resource access.
 * If the access token is not sufficient for the requested action, the Resource server MUST return errors as per section 3.1 of [RFC6750]{{RFC6750}}
-* MAY publish the {{OPRM}} to describe the metadata needed to interact with the protected resource.
+* MAY publish the {{RFC8414}} to describe the metadata needed to interact with the protected resource.
 
 ## Security Event Token
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -123,9 +123,9 @@ normative:
     -
       ins: A. Tulshibagwale
       name: Atul Tulshibagwale
-    date: August 2021
-    target: https://openid.net/specs/openid-caep-specification-1_0.html
-    title: OpenID Continuous Access Evaluation Profile 1.0 - draft 02
+    date: June 2024
+    target: https://openid.net/specs/openid-caep-1_0.html
+    title: OpenID Continuous Access Evaluation Profile 1.0 - draft 03
   RISC:
     author:
     -


### PR DESCRIPTION
There were a few links that used the old urls of the CAEP / SSF and some http links that should be https these days.