### PR TITLE
Fixes issue #208 - Poll endpoint should require authorization

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -78,7 +78,11 @@ contributor:
         name: James Slocum
         org: Beyond Identity
         email: james.slocum@beyondidentity.com
-
+      -
+        ins: J. Schreiber
+        name: Jen Schreiber
+        org: Workday
+        email: jennifer.winer@workday.com
 normative:
   CLIENTCRED:
     author:

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -816,7 +816,9 @@ TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
 {{RFC8414}}. This would allow other specs to add to the metadata.
 
 ### Authorization scheme {#authorization-scheme}
-SSF is an HTTP based signals sharing framework and is agnostic to the authentication and authorization schemes used to secure stream configuration APIs. It does not provide any SSF-specific authentication and authorization schemes but relies on the cooperating parties' mutual security considerations. The authorization scheme section of the metadata provides discovery information related to the Transmitter's stream management APIs.
+SSF is an HTTP based signals sharing framework and is agnostic to the authentication and authorization schemes used to secure stream configuration APIs. It does not provide any SSF-specific authentication and authorization schemes but relies on the cooperating parties' mutual security considerations.
+
+The `authorization_schemes` key of Transmitter Configuration Metadata provides authorization information related to the Transmitter's stream management APIs. These authorization schemes SHOULD also be used to protect any polling endpoint (used for Poll-Based SET delivery [RFC8936]) hosted by the Transmitter.
 
 spec_urn
 


### PR DESCRIPTION
Add text to section [7.1.1](https://openid.github.io/sharedsignals/openid-sharedsignals-framework-1_0.html#section-7.1.1) to state that authorization should be used for the Poll Endpoint

Fixes #208 