### PR TITLE
Fixes #221 - Add event_metadata to CAEP and RISC

### DIFF
--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -174,10 +174,9 @@ event_timestamp
   from 1970-01-01T0:0:0Z as measured in UTC until the date/time.
 
 event_metadata
-: OPTIONAL, JSON object: metadata specific to the event and or actions(s) in
- the event provided by the transmitter. The object MUST contain one or more
- key/value pairs. This claim SHOULD not be used to express information about
- the subject.
+: OPTIONAL, JSON object: metadata specific to the event provided by the
+Transmitter. The object MUST contain one or more key/value pairs. This claim
+SHOULD be used to express information about the event, not the subject.
 
 initiating_entity
 : OPTIONAL, JSON string: describes the entity that invoked the event.

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -173,6 +173,12 @@ event_timestamp
   occurred. Its value is a JSON number representing the number of seconds
   from 1970-01-01T0:0:0Z as measured in UTC until the date/time.
 
+event_metadata
+: OPTIONAL, JSON object: metadata specific to the event and or actions(s) in
+ the event provided by the transmitter. The object MUST contain one or more
+ key/value pairs. This claim SHOULD not be used to express information about
+ the subject.
+
 initiating_entity
 : OPTIONAL, JSON string: describes the entity that invoked the event.
 : This MUST be one of the following strings:

--- a/openid-risc-profile-specification-1_0.xml
+++ b/openid-risc-profile-specification-1_0.xml
@@ -94,6 +94,16 @@
       <t>The base URI for RISC event types is:<vspace />
         https://schemas.openid.net/secevent/risc/event-type/</t>
 
+      <section anchor="optional-event claims" title="Optional Event Claims">
+        <t>The following claims are optional unless otherwise specified in the event type definition.
+
+        <list style="symbols">
+          <t>event_metadata - optional, JSON object, metadata specific to the event and or actions(s) in
+            the event provided by the Transmitter. The object MUST contain one or more key/value pairs.
+            This claim SHOULD not be used to express information about the subject.</t>
+        </list></t>
+      </section>
+
       <section anchor="account-credential-change-required" title="Account Credential Change Required">
         <t>Event Type URI:<vspace />
         https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required</t>

--- a/openid-risc-profile-specification-1_0.xml
+++ b/openid-risc-profile-specification-1_0.xml
@@ -98,9 +98,9 @@
         <t>The following claims are optional unless otherwise specified in the event type definition.
 
         <list style="symbols">
-          <t>event_metadata - optional, JSON object, metadata specific to the event and or actions(s) in
-            the event provided by the Transmitter. The object MUST contain one or more key/value pairs.
-            This claim SHOULD not be used to express information about the subject.</t>
+          <t>event_metadata - optional, JSON object,metadata specific to the event provided by the
+          Transmitter. The object MUST contain one or more key/value pairs. This claim SHOULD be
+          used to express information about the event, not the subject.</t>
         </list></t>
       </section>
 


### PR DESCRIPTION
Added event_metadata to CAEP and RISC for the transmitter to provide additional information about the event itself.

Fixes #221 