### PR TITLE
Adding some language for recommended stream configuration audience validation

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1229,14 +1229,20 @@ Errors are signaled with HTTP status codes as follows:
 {: title="Create Stream Errors" #tablecreatestream}
 
 
+##### Validating a Stream Creation Response
+
+* `aud`: It is RECOMMENDED that the Receiver validates the `aud` in the Create Stream Response.
+In most cases, a Transmitter and Receiver will agree upon the audience value out of band. 
+Regardless of how the Receiver obtains the audience, it SHOULD ensure that it matches the
+response.
+
 #### Reading a Stream’s Configuration {#reading-a-streams-configuration}
 An Event Receiver gets the current configuration of a stream by making an HTTP
 GET request to the Configuration Endpoint. On receiving a valid request, the
 Event Transmitter responds with a "200 OK" response containing a [JSON][RFC7159]
 representation of the stream’s configuration in the body.  The Receiver
 MUST check the response and confirm that the `iss` value matches the Issuer from
-which it received the Transmitter Configuration data. It is RECOMMENDED that the
-Receiver validates the `aud` value matches what they expect.
+which it received the Transmitter Configuration data.
 
 The GET request MAY include the "stream_id" as a query parameter in order to
 identify the correct Event Stream. If the "stream_id" parameter is missing,

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1236,7 +1236,7 @@ Event Transmitter responds with a "200 OK" response containing a [JSON][RFC7159]
 representation of the stream’s configuration in the body.  The Receiver
 MUST check the response and confirm that the `iss` value matches the Issuer from
 which it received the Transmitter Configuration data. It is RECOMMENDED that the
-Receiver validates the `aud` matches the expected value.
+Receiver validates the `aud` value matches what they expect.
 
 The GET request MAY include the "stream_id" as a query parameter in order to
 identify the correct Event Stream. If the "stream_id" parameter is missing,

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1235,7 +1235,8 @@ GET request to the Configuration Endpoint. On receiving a valid request, the
 Event Transmitter responds with a "200 OK" response containing a [JSON][RFC7159]
 representation of the stream’s configuration in the body.  The Receiver
 MUST check the response and confirm that the `iss` value matches the Issuer from
-which it received the Transmitter Configuration data.
+which it received the Transmitter Configuration data. It is RECOMMENDED that the
+Receiver validates the `aud` matches the expected value.
 
 The GET request MAY include the "stream_id" as a query parameter in order to
 identify the correct Event Stream. If the "stream_id" parameter is missing,

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1233,7 +1233,7 @@ Errors are signaled with HTTP status codes as follows:
 
 * `aud`: the Receiver SHOULD validate the `aud` in the Create Stream Response.
 A Transmitter and Receiver MAY agree upon the audience value out of band.
-Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure that it matches what is expected.
+Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure that it matches what it expects.
 
 #### Reading a Stream’s Configuration {#reading-a-streams-configuration}
 An Event Receiver gets the current configuration of a stream by making an HTTP

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1231,10 +1231,9 @@ Errors are signaled with HTTP status codes as follows:
 
 ##### Validating a Stream Creation Response
 
-* `aud`: It is RECOMMENDED that the Receiver validates the `aud` in the Create Stream Response.
-In most cases, a Transmitter and Receiver will agree upon the audience value out of band. 
-Regardless of how the Receiver obtains the audience, it SHOULD ensure that it matches the
-response.
+* `aud`: the Receiver SHOULD validate the `aud` in the Create Stream Response.
+A Transmitter and Receiver MAY agree upon the audience value out of band.
+Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure that it matches what is expected.
 
 #### Reading a Stream’s Configuration {#reading-a-streams-configuration}
 An Event Receiver gets the current configuration of a stream by making an HTTP


### PR DESCRIPTION
This is an attempt at some language for recommending the validation of the audience in the stream configuration.

It seems quite vague.... As @FragLegs mentions in the issue, it could be good to be more concrete on what this audience value should be.

Fixes #207  