### PR TITLE
Clarify Stream Creation default delivery method behavior

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1154,10 +1154,12 @@ Configuration ({{stream-config}}) object:
 * `description`
 
 If the request does not contain the `delivery` property, then the Transmitter
-MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). The
-Transmitter MUST include a `delivery` property in the response with this
-`method` property and an `endpoint_url` property. Note that in the case of the poll
-method, the `endpoint_url` value is supplied by the Transmitter.
+MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). If the Transmitter supports
+Poll-Based Delivery, the Transmitter MUST include a `delivery` property in the response with this
+`method` property and an `endpoint_url` property. If the Transmitter does not support
+the delivery method, it MAY respond with 4XX HTTP Status Code such as "400 Bad Rquest."
+
+Note that in the case of the poll method, the `endpoint_url` value is supplied by the Transmitter.
 
 The following is a non-normative example request to create an Event Stream:
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1157,7 +1157,7 @@ If the request does not contain the `delivery` property, then the Transmitter
 MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). If the Transmitter supports
 Poll-Based Delivery, the Transmitter MUST include a `delivery` property in the response with this
 `method` property and an `endpoint_url` property. If the Transmitter does not support
-the delivery method, it MAY respond with 4XX HTTP Status Code such as "400 Bad Rquest."
+the delivery method, it can respond with 4XX HTTP Status Code such as "400 Bad Rquest."
 
 Note that in the case of the poll method, the `endpoint_url` value is supplied by the Transmitter.
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1157,7 +1157,7 @@ If the request does not contain the `delivery` property, then the Transmitter
 MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). If the Transmitter supports
 Poll-Based Delivery, the Transmitter MUST include a `delivery` property in the response with this
 `method` property and an `endpoint_url` property. If the Transmitter does not support
-the delivery method, it can respond with 4XX HTTP Status Code such as "400 Bad Rquest."
+the delivery method, it MAY respond with HTTP Status Code "400 Bad Request."
 
 Note that in the case of the poll method, the `endpoint_url` value is supplied by the Transmitter.
 


### PR DESCRIPTION
Fixes #149 

This PR should be non-normative (is it?!)  i've tried to better describe the default behavior when a transmitter does not support the defaulted stream delivery method. 
