### PR TITLE
Add examples for wildcard matching with Complex Subjects

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1888,7 +1888,7 @@ According to the matching rules described above, the Transmitter SHOULD broadcas
 event over the Receiver's stream.
 ~~~
 
-The following is a non-normative example of wildcard matching for Complex Subjects
+The following is a non-normative example of subject matching for Complex Subjects
 when a Receiver adds a subject that is more restrictive than the subject being sent
 by the Transmitter.
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1844,7 +1844,7 @@ Receiver wants to receive events about a particular subject by “adding” or
 
 #### Subject Matching {#subject-matching}
 
-If a Receiver adds a subject to a stream, the Transmitter SHOULD send any events
+If a Receiver adds a subject to a stream defined in {{adding-a-subject-to-a-stream}}, the Transmitter SHOULD send any events
 relating to the subject which have event_types that the Receiver has subscribed to,
 as long as the stream is enabled. In the case of Simple Subjects,
 two subjects match if they are exactly identical. For Complex Subjects, two subjects

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1857,7 +1857,7 @@ at least one of the following statements is true:
 
 3. Subject 1's field is identical to Subject 2's field
 
-The following is a non-normative example of wildcard matching for Complex Subjects
+The following is a non-normative example of subject matching for Complex Subjects
 when a Receiver adds a subject that is less restrictive than the subject being sent
 by the Transmitter.
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1846,7 +1846,7 @@ Receiver wants to receive events about a particular subject by “adding” or
 
 If a Receiver adds a subject to a stream defined in {{adding-a-subject-to-a-stream}}, the Transmitter SHOULD send any events
 relating to the subject which have event_types that the Receiver has subscribed to,
-as long as the stream is enabled. In the case of Simple Subjects,
+as long as the stream status is enabled. In the case of Simple Subjects,
 two subjects match if they are exactly identical. For Complex Subjects, two subjects
 match if, for all fields in the Complex Subject (i.e. `user`, `group`, `device`, etc.),
 at least one of the following statements is true:


### PR DESCRIPTION
This PR adds some examples of wildcard matching behavior for Complex Subjects. It does not change any definitions in the spec - simply gives examples of the definitions in practice.

Closes #197 