### PR TITLE
Fixes Issue #91 - Clean up markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,9 +1,9 @@
-# blanks around fences
+# blanks-around-fences
 MD031: false
+# no-bare-urls
 MD034: false
 # first-line-h1
-MD0041:
+MD041:
   allow_preamble: true
-  front_matter_title: "---"
-# MD055/table-pipe-style
+# table-pipe-style
 MD055: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -2,6 +2,8 @@ default: true
 MD013:
   line_length: 80
   tables: false
+  code_blocks: false
+  stern: true
 # blanks-around-fences false because of kramdown-rfc formatting
 MD031: false
 # no-bare-urls

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
+default: true
 MD013:
-  line_length: 20000
+  line_length: 80
+  tables: false
 # blanks-around-fences false because of kramdown-rfc formatting
 MD031: false
 # no-bare-urls

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+# blanks around fences
+MD031: false
+MD034: false
+# first-line-h1
+MD0041:
+  allow_preamble: true
+  front_matter_title: "---"
+# MD055/table-pipe-style
+MD055: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,9 +1,12 @@
-# blanks-around-fences
+MD013:
+  line_length: 20000
+# blanks-around-fences false because of kramdown-rfc formatting
 MD031: false
 # no-bare-urls
 MD034: false
-# first-line-h1
-MD041:
-  allow_preamble: true
-# table-pipe-style
+# first-line-h1 false because of rfc heading
+MD041: false
+# table-pipe-style and table-column-count set to false
+# these conflict with the table title kramdown-rfc formatting
 MD055: false
+MD056: false

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -1,9 +1,9 @@
 ---
-title: OpenID Continuous Access Evaluation Profile 1.0 - draft 11
+title: OpenID Continuous Access Evaluation Profile 1.0 - draft 12
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-05-22
+date: 2025-05-29
 
 ipr: none
 cat: std
@@ -1043,6 +1043,10 @@ cover technology that may be required to practice this specification.
 # Document History
 
   [[ To be removed from the final specification ]]
+
+-12
+
+* Cleaned up markdown (#91)
 
 -10
 

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -5,7 +5,7 @@ abbrev: CAEP-Spec
 docname: openid-caep-1_0
 date: 2025-05-19
 
-ipr: none 
+ipr: none
 cat: std
 wg: Shared Signals
 
@@ -161,6 +161,7 @@ robotic users, devices, sessions and applications.
 --- middle
 
 # Introduction {#introduction}
+
 CAEP is the application of the Shared Signals Profile of IETF
 Security Events 1.0 {{SSF}} (SSF Profile) to ensure access security in a
 network of cooperating providers. CAEP specifies a set of event-types that
@@ -168,12 +169,14 @@ conform to the SSF Profile. This document specifies the event-types required to
 achieve this goal.
 
 ## Notational Considerations
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in BCP 14 {{RFC2119}} {{RFC8174}}
 when, and only when, they appear in all capitals, as shown here.
 
 # Optional Event Claims {#optional-event-claims}
+
 The following claims are optional unless otherwise specified in the event
 definition.
 
@@ -186,13 +189,13 @@ initiating_entity
 : OPTIONAL, JSON string: describes the entity that invoked the event.
 : This MUST be one of the following strings:
 
-  - `admin`:    an administrative action triggered the event
+* `admin`:    an administrative action triggered the event
 
-  - `user`:     an end-user action triggered the event
+* `user`:     an end-user action triggered the event
 
-  - `policy`:   a policy evaluation triggered the event
+* `policy`:   a policy evaluation triggered the event
 
-  - `system`:   a system or platform assertion triggered the event
+* `system`:   a system or platform assertion triggered the event
 
 reason_admin
 : OPTIONAL, JSON object: a localizable administrative message intended for
@@ -228,13 +231,14 @@ message as the value.
 ~~~
 {: #optional-claims-reason-user-example title="Example: End user reason information with multiple languages"}
 
-
 # Event Types {#event-types}
+
 The base URI for CAEP event types is:
 
 `https://schemas.openid.net/secevent/caep/event-type/`
 
 ## Session Revoked {#session-revoked}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/session-revoked`
@@ -363,6 +367,7 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
 {: #session-revoked-example-user-device title="Example: Session Revoked - Complex Subject describing user + device + tenant (includes optional claims)"}
 
 ## Token Claims Change {#token-claims-change}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/token-claims-change`
@@ -466,8 +471,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
 ~~~
 {: #token-claims-change-example-saml title="Example: SAML Assertion Claims Change - Required claims only"}
 
-
 ## Credential Change {#credential-change}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/credential-change`
@@ -475,9 +480,9 @@ Event Type URI:
 The Credential Change event signals that a credential was created, changed,
 revoked or deleted. Credential Change scenarios include:
 
-  - password/PIN change/reset
-  - certificate enrollment, renewal, revocation and deletion
-  - second factor / passwordless credential enrollment or deletion (U2F, FIDO2, OTP, app-based)
+* password/PIN change/reset
+* certificate enrollment, renewal, revocation and deletion
+* second factor / passwordless credential enrollment or deletion (U2F, FIDO2, OTP, app-based)
 
 The actual reason why the credential change occurred might be specified with the
 nested `reason_admin` and/or `reason_user` claims made in {{optional-event-claims}}.
@@ -488,24 +493,24 @@ credential_type
 : REQUIRED, JSON string: This MUST be one of the following strings, or any other
 credential type supported mutually by the Transmitter and the Receiver.
 
-    - `password`
-    - `pin`
-    - `x509`
-    - `fido2-platform`
-    - `fido2-roaming`
-    - `fido-u2f`
-    - `verifiable-credential`
-    - `phone-voice`
-    - `phone-sms`
-    - `app`
+* `password`
+* `pin`
+* `x509`
+* `fido2-platform`
+* `fido2-roaming`
+* `fido-u2f`
+* `verifiable-credential`
+* `phone-voice`
+* `phone-sms`
+* `app`
 
 change_type
 : REQUIRED, JSON string: This MUST be one of the following strings:
 
-    - `create`
-    - `revoke`
-    - `update`
-    - `delete`
+* `create`
+* `revoke`
+* `update`
+* `delete`
 
 friendly_name
 : OPTIONAL, JSON string: credential friendly name
@@ -556,6 +561,7 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
 {: #credential-change-example-fido2 title="Example: Provisioning a new FIDO2 authenticator - Simple Subject + optional claims"}
 
 ## Assurance Level Change {#assurance-level-change}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/assurance-level-change`
@@ -581,13 +587,13 @@ namespace:
 : REQUIRED, JSON string: the namespace of the values in the `current_level` and `previous_level` claims.
 This string MAY be one of the following strings:
 
-  - `RFC8176`: The assurance level values are from the {{RFC8176}} specification
-  - `RFC6711`: The assurance level values are from the {{RFC6711}} specification
-  - `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}} specification
-  - `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}} specification
-  - `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}} specification
-  - `NIST-FAL`: The assurance level values are from the {{NIST-FED}} specification
-  - Any other value that is an alias for a custom namespace agreed between the Transmitter and the Receiver
+* `RFC8176`: The assurance level values are from the {{RFC8176}} specification
+* `RFC6711`: The assurance level values are from the {{RFC6711}} specification
+* `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}} specification
+* `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}} specification
+* `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}} specification
+* `NIST-FAL`: The assurance level values are from the {{NIST-FED}} specification
+* Any other value that is an alias for a custom namespace agreed between the Transmitter and the Receiver
 
 current_level
 : REQUIRED, JSON string: The current assurance level, as defined in the specified `namespace`
@@ -601,8 +607,8 @@ change_direction
 If the Transmitter has specified the `previous_level`, then the Transmitter SHOULD provide a value for this claim.
 If present, this MUST be one of the following strings:
 
-  - `increase`
-  - `decrease`
+* `increase`
+* `decrease`
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the assurance level changed.
@@ -659,8 +665,8 @@ the assurance level changed.
 ~~~
 {: #assurance-level-change-examples-custom title="Example: Custom Assurance Level - Simple Subject"}
 
-
 ## Device Compliance Change {#device-compliance-change}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/device-compliance-change`
@@ -676,15 +682,15 @@ previous_status
 : REQUIRED, JSON string: the compliance status prior to the change that triggered the event
 : This MUST be one of the following strings:
 
-  - `compliant`
-  - `not-compliant`
+* `compliant`
+* `not-compliant`
 
 current_status
 : REQUIRED, JSON string: the current status that triggered the event
 : This MUST be one of the following strings:
 
-  - `compliant`
-  - `not-compliant`
+* `compliant`
+* `not-compliant`
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the device compliance status changed.
@@ -731,6 +737,7 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
 {: #device-compliance-change-examples-out-of-compliance title="Example: Device No Longer Compliant - Complex Subject + optional claims"}
 
 ## Session Established {#session-established}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/session-established`
@@ -744,6 +751,7 @@ The Session Established event signifies that the Transmitter has established a n
 The `event_timestamp` in this event type specifies the time at which the session was established.
 
 ### Event Specific Claims {#session-established-event-specific-claims}
+
 The following optional claims MAY be included in the Session Established event:
 
 fp_ua
@@ -758,8 +766,8 @@ amr
 ext_id
 : The external session identifier, which may be used to correlate this session with a broader session (e.g., a federated session established using SAML)
 
-
 ### Examples {#session-established-examples}
+
 The following is a non-normative example of the `session-established` event type:
 
 ~~~json
@@ -785,6 +793,7 @@ The following is a non-normative example of the `session-established` event type
 ~~~
 
 ## Session Presented {#session-presented}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/session-presented`
@@ -795,6 +804,7 @@ The Session Presented event signifies that the Transmitter has observed the sess
 * Establishing an inventory of live sessions belonging to a user
 
 ### Event Specific Claims {#session-presented-event-specific-claims}
+
 The following optional claims MAY be present in a Session Presented event:
 
 fp_ua
@@ -804,6 +814,7 @@ ext_id
 : The external session identifier, which may be used to correlate this session with a broader session (e.g., a federated session established using SAML)
 
 ### Examples {#session-presented-examples}
+
 The following is a non-normative example of a Session Presented event:
 
 ~~~json
@@ -828,6 +839,7 @@ The following is a non-normative example of a Session Presented event:
 ~~~
 
 ## Risk Level Change {#risk-level-change}
+
 Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/risk-level-change`
@@ -840,7 +852,6 @@ The Risk Level Change event is employed by the Transmitter to communicate any mo
 * Device's risk has changed due to installation of unapproved software, connection to insecure pheripheral device, encryption of data or other reasons.
 * Any other subject's risk changes due to variety of reasons.
 
-
 ### Event Specific Claims {#risk-level-change-event-specific-claims}
 
 risk_reason
@@ -849,14 +860,14 @@ risk_reason
 principal
 : REQUIRED, JSON string: representing the principal entity involved in the observed risk event, as identified by the transmitter. The subject principal can be one of the following entities USER, DEVICE, SESSION, TENANT, ORG_UNIT, GROUP, or any other entity as defined in Section 2 of {{SSF}}. This claim identifies the primary subject associated with the event, and helps to contextualize the risk relative to the entity involved.
 
-current_level 
+current_level
 : REQUIRED, JSON string: indicates the current level of the risk for the subject. Value MUST be one of LOW, MEDIUM, HIGH
 
-previous_level 
+previous_level
 : OPTIONAL, JSON string: indicates the previously known level of the risk for the subject. Value MUST be one of LOW, MEDIUM, HIGH. If the Transmitter omits this value, the Receiver MUST assume that the previous risk level is unknown to the Transmitter.
 
-
 ### Examples {#risk-level-change-examples}
+
 The following is a non-normative example of a Risk Level Change event:
 
 ~~~json
@@ -884,6 +895,7 @@ The following is a non-normative example of a Risk Level Change event:
 ~~~
 
 # Security Considerations
+
 Any implementations of events described in this document SHOULD comply with the Shared Signals Framework {{SSF}}. Exchanging events described herein without complying with the Shared Signals Framework {{SSF}} may result in security issues.
 
 --- back
@@ -906,15 +918,16 @@ The technology described in this specification was made available from contribut
 
   [[ To be removed from the final specification ]]
 
-  -10
-  * Fixed the example for the "session established" event
-  * ip claims removed from session established and session presented
-  * New "Risk level change" event
+-10
 
-  -03
+* Fixed the example for the "session established" event
+* ip claims removed from session established and session presented
+* New "Risk level change" event
 
-  * New "Session Established" and "Session Presented" event types
-  * Added `namespace` required field to Assurance Level Change event
-  * Changed the name referencing SSE to SSF
-  * Added `format` to the subjects in examples in CAEP
-  * Formatting and typo changes
+-03
+
+* New "Session Established" and "Session Presented" event types
+* Added `namespace` required field to Assurance Level Change event
+* Changed the name referencing SSE to SSF
+* Added `format` to the subjects in examples in CAEP
+* Formatting and typo changes

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -3,7 +3,7 @@ title: OpenID Continuous Access Evaluation Profile 1.0 - draft 11
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-05-19
+date: 2025-05-21
 
 ipr: none
 cat: std
@@ -40,14 +40,16 @@ contributor:
 normative:
   ISO-IEC-29115:
     target: https://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=45138
-    title: "ISO/IEC 29115:2013 -- Information technology - Security techniques - Entity authentication assurance framework"
+    title: "ISO/IEC 29115:2013 -- Information technology - Security techniques -
+     Entity authentication assurance framework"
     author:
       -
         name: "International Organization for Standardization"
     date: March 2013
   NIST-AUTH:
     target: https://pages.nist.gov/800-63-3/sp800-63-3.html
-    title: "Digital Identity Guidelines, Authentication and Lifecycle Management"
+    title: "Digital Identity Guidelines, Authentication and Lifecycle
+     Management"
     author:
       -
         ins: P. Grassi
@@ -141,7 +143,8 @@ normative:
     date: 2024-06-25
   WebAuthn:
     target: https://www.w3.org/TR/webauthn/
-    title: "Web Authentication: An API for accessing Public Key Credentials Level 2"
+    title: "Web Authentication: An API for accessing Public Key Credentials
+     Level 2"
     author:
       -
         ins: D. Balfanz
@@ -153,10 +156,10 @@ normative:
 
 This document defines the Continuous Access Evaluation Profile (CAEP) of the
 Shared Signals Framework {{SSF}}. It specifies a set of event
-types conforming to the Shared Signals Framework. These event types are intended to be used
-between cooperating Transmitters and Receivers such that Transmitters may send
-continuous updates using which Receivers can attenuate access to shared human or
-robotic users, devices, sessions and applications.
+types conforming to the Shared Signals Framework. These event types are intended
+to be used between cooperating Transmitters and Receivers such that Transmitters
+may send continuous updates using which Receivers can attenuate access to shared
+human or robotic users, devices, sessions and applications.
 
 --- middle
 
@@ -212,7 +215,8 @@ administrative message as the value.
     }
 }
 ~~~
-{: #optional-claims-reason-admin-example title="Example: Administrative reason information with multiple languages"}
+{: #optional-claims-reason-admin-example title="Example: Administrative reason
+information with multiple languages"}
 
 reason_user
 : OPTIONAL, JSON object: a localizable user-friendly message for display
@@ -229,7 +233,8 @@ message as the value.
     }
 }
 ~~~
-{: #optional-claims-reason-user-example title="Example: End user reason information with multiple languages"}
+{: #optional-claims-reason-user-example title="Example: End user reason
+information with multiple languages"}
 
 # Event Types {#event-types}
 
@@ -252,7 +257,8 @@ When a Complex Claim is used as the subject, the revocation event applies
 to any session derived from matching those combined claims.
 
 The actual reason why the session was revoked might be specified with the
-nested `reason_admin` and/or `reason_user` claims described in {{optional-event-claims}}.
+nested `reason_admin` and/or `reason_user` claims described in
+{{optional-event-claims}}.
 
 ### Event-Specific Claims {#session-revoked-claims}
 
@@ -263,7 +269,8 @@ the session revocation occurred.
 
 ### Examples  {#session-revoked-examples}
 
-NOTE: The event type URI is wrapped, the backslash is the continuation character.
+NOTE: The event type URI is wrapped, the backslash is the continuation
+character.
 
 ~~~ json
 {
@@ -283,7 +290,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #session-revoked-example-session-id-req title="Example: Session Revoked - Required claims + Simple Subject"}
+{: #session-revoked-example-session-id-req title="Example: Session Revoked -
+Required claims + Simple Subject"}
 
 ~~~ json
 {
@@ -323,7 +331,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #session-revoked-example-user-sub title="Example: Session Revoked - subject as `sub` claim (includes optional claims)"}
+{: #session-revoked-example-user-sub title="Example: Session Revoked - subject
+as `sub` claim (includes optional claims)"}
 
 ~~~ json
 {
@@ -364,7 +373,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #session-revoked-example-user-device title="Example: Session Revoked - Complex Subject describing user + device + tenant (includes optional claims)"}
+{: #session-revoked-example-user-device title="Example: Session Revoked -
+Complex Subject describing user + device + tenant (includes optional claims)"}
 
 ## Token Claims Change {#token-claims-change}
 
@@ -376,7 +386,8 @@ Token Claims Change signals that a claim in a token, identified by the
 subject claim, has changed.
 
 The actual reason why the claims change occurred might be specified with the
-nested `reason_admin` and/or `reason_user` claims made in {{optional-event-claims}}.
+nested `reason_admin` and/or `reason_user` claims made in
+{{optional-event-claims}}.
 
 ### Event-Specific Claims {#token-claims-change-claims}
 
@@ -388,7 +399,8 @@ the claim value(s) changed.
 
 ### Examples  {#token-claims-change-examples}
 
-NOTE: The event type URI is wrapped, the backslash is the continuation character.
+NOTE: The event type URI is wrapped, the backslash is the continuation
+character.
 
 ~~~ json
 {
@@ -412,7 +424,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #token-claims-change-example-oidc title="Example: OIDC ID Token Claims Change - Required claims only"}
+{: #token-claims-change-example-oidc title="Example: OIDC ID Token Claims
+Change - Required claims only"}
 
 ~~~ json
 {
@@ -445,7 +458,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #token-claims-change-example-oidc-optional title="Example: OIDC ID Token Claims Change - Optional claims"}
+{: #token-claims-change-example-oidc-optional title="Example: OIDC ID Token
+Claims Change - Optional claims"}
 
 ~~~json
 {
@@ -469,7 +483,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #token-claims-change-example-saml title="Example: SAML Assertion Claims Change - Required claims only"}
+{: #token-claims-change-example-saml title="Example: SAML Assertion Claims
+ Change - Required claims only"}
 
 ## Credential Change {#credential-change}
 
@@ -482,10 +497,12 @@ revoked or deleted. Credential Change scenarios include:
 
 * password/PIN change/reset
 * certificate enrollment, renewal, revocation and deletion
-* second factor / passwordless credential enrollment or deletion (U2F, FIDO2, OTP, app-based)
+* second factor / passwordless credential enrollment or deletion (U2F, FIDO2,
+OTP, app-based)
 
 The actual reason why the credential change occurred might be specified with the
-nested `reason_admin` and/or `reason_user` claims made in {{optional-event-claims}}.
+nested `reason_admin` and/or `reason_user` claims made in
+{{optional-event-claims}}.
 
 ### Event-Specific Claims {#credential-change-claims}
 
@@ -516,20 +533,24 @@ friendly_name
 : OPTIONAL, JSON string: credential friendly name
 
 x509_issuer
-: OPTIONAL, JSON string: issuer of the X.509 certificate as defined in {{RFC5280}}
+: OPTIONAL, JSON string: issuer of the X.509 certificate as defined in
+{{RFC5280}}
 
 x509_serial
-: OPTIONAL, JSON string: serial number of the X.509 certificate as defined in {{RFC5280}}
+: OPTIONAL, JSON string: serial number of the X.509 certificate as defined in
+{{RFC5280}}
 
 fido2_aaguid
-: OPTIONAL, JSON string: FIDO2 Authenticator Attestation GUID as defined in {{WebAuthn}}
+: OPTIONAL, JSON string: FIDO2 Authenticator Attestation GUID as defined in
+{{WebAuthn}}
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the credential change occurred.
 
 ### Examples  {#credential-change-examples}
 
-NOTE: The event type URI is wrapped, the backslash is the continuation character.
+NOTE: The event type URI is wrapped, the backslash is the continuation
+character.
 
 ~~~json
 {
@@ -558,7 +579,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #credential-change-example-fido2 title="Example: Provisioning a new FIDO2 authenticator - Simple Subject + optional claims"}
+{: #credential-change-example-fido2 title="Example: Provisioning a new FIDO2
+ authenticator - Simple Subject + optional claims"}
 
 ## Assurance Level Change {#assurance-level-change}
 
@@ -579,32 +601,43 @@ Assurance Level Change event will signal to Service Provider A that user has
 authenticated with a stronger authentication method.
 
 The actual reason why the assurance level changed might be specified with the
-nested `reason_admin` and/or `reason_user` claims made in {{optional-event-claims}}.
+nested `reason_admin` and/or `reason_user` claims made in
+{{optional-event-claims}}.
 
 ### Event-Specific Claims {#assurance-level-change-claims}
 
 namespace:
-: REQUIRED, JSON string: the namespace of the values in the `current_level` and `previous_level` claims.
+: REQUIRED, JSON string: the namespace of the values in the `current_level` and
+`previous_level` claims.
 This string MAY be one of the following strings:
 
 * `RFC8176`: The assurance level values are from the {{RFC8176}} specification
 * `RFC6711`: The assurance level values are from the {{RFC6711}} specification
-* `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}} specification
-* `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}} specification
-* `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}} specification
-* `NIST-FAL`: The assurance level values are from the {{NIST-FED}} specification
-* Any other value that is an alias for a custom namespace agreed between the Transmitter and the Receiver
+* `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}}
+specification
+* `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}}
+specification
+* `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}}
+specification
+* `NIST-FAL`: The assurance level values are from the {{NIST-FED}}
+specification
+* Any other value that is an alias for a custom namespace agreed between the
+Transmitter and the Receiver
 
 current_level
-: REQUIRED, JSON string: The current assurance level, as defined in the specified `namespace`
+: REQUIRED, JSON string: The current assurance level, as defined in the
+specified `namespace`
 
 previous_level
-: OPTIONAL, JSON string: the previous assurance level, as defined in the specified `namespace`
-If the Transmitter omits this value, the Receiver MUST assume that the previous assurance level is unknown to the Transmitter
+: OPTIONAL, JSON string: the previous assurance level, as defined in the
+specified `namespace`
+If the Transmitter omits this value, the Receiver MUST assume that the previous
+assurance level is unknown to the Transmitter
 
 change_direction
 : OPTIONAL, JSON string: the assurance level increased or decreased
-If the Transmitter has specified the `previous_level`, then the Transmitter SHOULD provide a value for this claim.
+If the Transmitter has specified the `previous_level`, then the Transmitter
+SHOULD provide a value for this claim.
 If present, this MUST be one of the following strings:
 
 * `increase`
@@ -639,7 +672,8 @@ the assurance level changed.
     }
 }
 ~~~
-{: #assurance-level-change-examples-al-increase title="Example: Assurance Level Increase - Simple Subject + optional claims"}
+{: #assurance-level-change-examples-al-increase title="Example: Assurance Level
+ Increase - Simple Subject + optional claims"}
 
 ~~~json
 {
@@ -663,7 +697,8 @@ the assurance level changed.
     }
 }
 ~~~
-{: #assurance-level-change-examples-custom title="Example: Custom Assurance Level - Simple Subject"}
+{: #assurance-level-change-examples-custom title="Example: Custom Assurance
+ Level - Simple Subject"}
 
 ## Device Compliance Change {#device-compliance-change}
 
@@ -674,12 +709,14 @@ Event Type URI:
 Device Compliance Change signals that a device's compliance status has changed.
 
 The actual reason why the status change occurred might be specified with the
-nested `reason_admin` and/or `reason_user` claims made in {{optional-event-claims}}.
+nested `reason_admin` and/or `reason_user` claims made in
+{{optional-event-claims}}.
 
 ### Event-Specific Claims {#device-compliance-change-claims}
 
 previous_status
-: REQUIRED, JSON string: the compliance status prior to the change that triggered the event
+: REQUIRED, JSON string: the compliance status prior to the change that
+triggered the event
 : This MUST be one of the following strings:
 
 * `compliant`
@@ -697,7 +734,8 @@ the device compliance status changed.
 
 ### Examples  {#device-compliance-change-examples}
 
-NOTE: The event type URI is wrapped, the backslash is the continuation character.
+NOTE: The event type URI is wrapped, the backslash is the continuation
+character.
 
 ~~~json
 {
@@ -734,7 +772,8 @@ NOTE: The event type URI is wrapped, the backslash is the continuation character
     }
 }
 ~~~
-{: #device-compliance-change-examples-out-of-compliance title="Example: Device No Longer Compliant - Complex Subject + optional claims"}
+{: #device-compliance-change-examples-out-of-compliance title="Example: Device
+ No Longer Compliant - Complex Subject + optional claims"}
 
 ## Session Established {#session-established}
 
@@ -742,33 +781,45 @@ Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/session-established`
 
-The Session Established event signifies that the Transmitter has established a new session for the subject. Receivers may use this information for a number of reasons, including:
+The Session Established event signifies that the Transmitter has established a
+new session for the subject. Receivers may use this information for a number of
+reasons, including:
 
-* A service acting as a Transmitter can close the loop with the IdP after a user has been federated from the IdP
+* A service acting as a Transmitter can close the loop with the IdP after a user
+has been federated from the IdP
 * An IdP can detect unintended logins
 * A Receiver can establish an inventory of user sessions
 
-The `event_timestamp` in this event type specifies the time at which the session was established.
+The `event_timestamp` in this event type specifies the time at which the session
+was established.
 
 ### Event Specific Claims {#session-established-event-specific-claims}
 
 The following optional claims MAY be included in the Session Established event:
 
 fp_ua
-: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is not to identify the session, but to present some qualities of the session)
+: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
+not to identify the session, but to present some qualities of the session)
 
 acr
-: The authentication context class reference of the session, as established by the Transmitter. The value of this field MUST be interpreted in the same way as the corresponding field in an OpenID Connect ID Token {{OpenID.Core}}
+: The authentication context class reference of the session, as established by
+the Transmitter. The value of this field MUST be interpreted in the same way as
+the corresponding field in an OpenID Connect ID Token {{OpenID.Core}}
 
 amr
-: The authentication methods reference of the session, as established by the Transmitter. The value of this field MUST be an array of strings, each of which MUST be interpreted in the same way as the corresponding field in an OpenID Connect ID Token {{OpenID.Core}}
+: The authentication methods reference of the session, as established by the
+Transmitter. The value of this field MUST be an array of strings, each of which
+MUST be interpreted in the same way as the corresponding field in an OpenID
+Connect ID Token {{OpenID.Core}}
 
 ext_id
-: The external session identifier, which may be used to correlate this session with a broader session (e.g., a federated session established using SAML)
+: The external session identifier, which may be used to correlate this session
+with a broader session (e.g., a federated session established using SAML)
 
 ### Examples {#session-established-examples}
 
-The following is a non-normative example of the `session-established` event type:
+The following is a non-normative example of the `session-established` event
+type:
 
 ~~~json
 {
@@ -798,7 +849,10 @@ Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/session-presented`
 
-The Session Presented event signifies that the Transmitter has observed the session to be present at the Transmitter at the time indicated by the `event_timestamp` field in the Session Presented event. Receivers may use this information for reasons that include:
+The Session Presented event signifies that the Transmitter has observed the
+session to be present at the Transmitter at the time indicated by the
+`event_timestamp` field in the Session Presented event. Receivers may use this
+information for reasons that include:
 
 * Detecting abnormal user activity
 * Establishing an inventory of live sessions belonging to a user
@@ -808,10 +862,12 @@ The Session Presented event signifies that the Transmitter has observed the sess
 The following optional claims MAY be present in a Session Presented event:
 
 fp_ua
-: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is not to identify the session, but to present some qualities of the session)
+: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
+not to identify the session, but to present some qualities of the session)
 
 ext_id
-: The external session identifier, which may be used to correlate this session with a broader session (e.g., a federated session established using SAML)
+: The external session identifier, which may be used to correlate this session
+with a broader session (e.g., a federated session established using SAML)
 
 ### Examples {#session-presented-examples}
 
@@ -844,27 +900,47 @@ Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/risk-level-change`
 
-A vendor may deploy mechanisms to gather and analyze various signals associated with subjects such as users, devices, etc. These signals, which can originate from diverse channels and methods beyond the scope of this event description, are processed to derive an abstracted risk level representing the subject's current threat status.
+A vendor may deploy mechanisms to gather and analyze various signals associated
+with subjects such as users, devices, etc. These signals, which can originate
+from diverse channels and methods beyond the scope of this event description,
+are processed to derive an abstracted risk level representing the subject's
+current threat status.
 
-The Risk Level Change event is employed by the Transmitter to communicate any modifications in a subject's assessed risk level at the time indicated by the `event_timestamp` field in the Risk Level Change event. The Transmitter may generate this event to indicate:
+The Risk Level Change event is employed by the Transmitter to communicate any
+modifications in a subject's assessed risk level at the time indicated by the
+`event_timestamp` field in the Risk Level Change event. The Transmitter may
+generate this event to indicate:
 
-* User's risk has changed due to potential suspecious access from unknown destination, password compromise, addition of strong authenticator or other reasons.
-* Device's risk has changed due to installation of unapproved software, connection to insecure pheripheral device, encryption of data or other reasons.
+* User's risk has changed due to potential suspecious access from unknown
+destination, password compromise, addition of strong authenticator or other
+reasons.
+* Device's risk has changed due to installation of unapproved software,
+connection to insecure pheripheral device, encryption of data or other reasons.
 * Any other subject's risk changes due to variety of reasons.
 
 ### Event Specific Claims {#risk-level-change-event-specific-claims}
 
 risk_reason
-: RECOMMENDED, JSON string: indicates the reason that contributed to the risk level changes by the Transmitter.
+: RECOMMENDED, JSON string: indicates the reason that contributed to the risk
+level changes by the Transmitter.
 
 principal
-: REQUIRED, JSON string: representing the principal entity involved in the observed risk event, as identified by the transmitter. The subject principal can be one of the following entities USER, DEVICE, SESSION, TENANT, ORG_UNIT, GROUP, or any other entity as defined in Section 2 of {{SSF}}. This claim identifies the primary subject associated with the event, and helps to contextualize the risk relative to the entity involved.
+: REQUIRED, JSON string: representing the principal entity involved in the
+observed risk event, as identified by the transmitter. The subject principal can
+be one of the following entities USER, DEVICE, SESSION, TENANT, ORG_UNIT, GROUP,
+or any other entity as defined in Section 2 of {{SSF}}. This claim identifies
+the primary subject associated with the event, and helps to contextualize the
+risk relative to the entity involved.
 
 current_level
-: REQUIRED, JSON string: indicates the current level of the risk for the subject. Value MUST be one of LOW, MEDIUM, HIGH
+: REQUIRED, JSON string: indicates the current level of the risk for the
+subject. Value MUST be one of LOW, MEDIUM, HIGH
 
 previous_level
-: OPTIONAL, JSON string: indicates the previously known level of the risk for the subject. Value MUST be one of LOW, MEDIUM, HIGH. If the Transmitter omits this value, the Receiver MUST assume that the previous risk level is unknown to the Transmitter.
+: OPTIONAL, JSON string: indicates the previously known level of the risk for
+the subject. Value MUST be one of LOW, MEDIUM, HIGH. If the Transmitter omits
+this value, the Receiver MUST assume that the previous risk level is unknown to
+the Transmitter.
 
 ### Examples {#risk-level-change-examples}
 
@@ -896,7 +972,10 @@ The following is a non-normative example of a Risk Level Change event:
 
 # Security Considerations
 
-Any implementations of events described in this document SHOULD comply with the Shared Signals Framework {{SSF}}. Exchanging events described herein without complying with the Shared Signals Framework {{SSF}} may result in security issues.
+Any implementations of events described in this document SHOULD comply with the
+Shared Signals Framework {{SSF}}. Exchanging events described herein without
+complying with the Shared Signals Framework {{SSF}} may result in security
+issues.
 
 --- back
 
@@ -910,9 +989,34 @@ specification.
 
 Copyright (c) 2024 The OpenID Foundation.
 
-The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer, or other interested party a non-exclusive, royalty free, worldwide copyright license to reproduce, prepare derivative works from, distribute, perform and display, this Implementers Draft or Final Specification solely for the purposes of (i) developing specifications, and (ii) implementing Implementers Drafts and Final Specifications based on such documents, provided that attribution be made to the OIDF as the source of the material, but that such attribution does not indicate an endorsement by the OIDF.
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright
+license to reproduce, prepare derivative works from, distribute, perform and
+display, this Implementers Draft or Final Specification solely for the purposes
+of (i) developing specifications, and (ii) implementing Implementers Drafts and
+Final Specifications based on such documents, provided that attribution be made
+to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
 
-The technology described in this specification was made available from contributions from various sources, including members of the OpenID Foundation and others. Although the OpenID Foundation has taken steps to help ensure that the technology is available for distribution, it takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this specification or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any independent effort to identify any such rights. The OpenID Foundation and the contributors to this specification make no (and hereby expressly disclaim any) warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to this specification, and the entire risk as to implementing this specification is assumed by the implementer. The OpenID Intellectual Property Rights policy requires contributors to offer a patent promise not to assert certain patent claims against other contributors and against implementers. The OpenID Foundation invites any interested party to bring to its attention any copyrights, patents, patent applications, or other proprietary rights that may cover technology that may be required to practice this specification.
+The technology described in this specification was made available from
+contributions from various sources, including members of the OpenID Foundation
+and others. Although the OpenID Foundation has taken steps to help ensure that
+the technology is available for distribution, it takes no position regarding the
+validity or scope of any intellectual property or other rights that might be
+claimed to pertain to the implementation or use of the technology described in
+this specification or the extent to which any license under such rights might or
+might not be available; neither does it represent that it has made any
+independent effort to identify any such rights. The OpenID Foundation and the
+contributors to this specification make no (and hereby expressly disclaim any)
+warranties (express, implied, or otherwise), including implied warranties of
+merchantability, non-infringement, fitness for a particular purpose, or title,
+related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy requires contributors to offer a patent promise not to assert
+certain patent claims against other contributors and against implementers. The
+OpenID Foundation invites any interested party to bring to its attention any
+copyrights, patents, patent applications, or other proprietary rights that may
+cover technology that may be required to practice this specification.
 
 # Document History
 

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -3,7 +3,7 @@ title: OpenID Continuous Access Evaluation Profile 1.0 - draft 11
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-05-21
+date: 2025-05-22
 
 ipr: none
 cat: std
@@ -184,24 +184,24 @@ The following claims are optional unless otherwise specified in the event
 definition.
 
 event_timestamp
-: OPTIONAL, JSON number: the time at which the event described by this SET
+
+> OPTIONAL, JSON number: the time at which the event described by this SET
   occurred. Its value is a JSON number representing the number of seconds
   from 1970-01-01T0:0:0Z as measured in UTC until the date/time.
 
 initiating_entity
-: OPTIONAL, JSON string: describes the entity that invoked the event.
-: This MUST be one of the following strings:
 
-* `admin`:    an administrative action triggered the event
-
-* `user`:     an end-user action triggered the event
-
-* `policy`:   a policy evaluation triggered the event
-
-* `system`:   a system or platform assertion triggered the event
+> OPTIONAL, JSON string: describes the entity that invoked the event.
+> This MUST be one of the following strings:
+>
+> * `admin`:    an administrative action triggered the event
+> * `user`:     an end-user action triggered the event
+> * `policy`:   a policy evaluation triggered the event
+> * `system`:   a system or platform assertion triggered the event
 
 reason_admin
-: OPTIONAL, JSON object: a localizable administrative message intended for
+
+> OPTIONAL, JSON object: a localizable administrative message intended for
 logging and auditing. The object MUST contain one or more key/value pairs,
 with a BCP47 {{RFC5646}} language tag as the key and the locale-specific
 administrative message as the value.
@@ -219,7 +219,8 @@ administrative message as the value.
 information with multiple languages"}
 
 reason_user
-: OPTIONAL, JSON object: a localizable user-friendly message for display
+
+> OPTIONAL, JSON object: a localizable user-friendly message for display
 to an end-user. The object MUST contain one or more key/value pairs, with a
 BCP47 {{RFC5646}} language tag as the key and the locale-specific end-user
 message as the value.
@@ -392,7 +393,8 @@ nested `reason_admin` and/or `reason_user` claims made in
 ### Event-Specific Claims {#token-claims-change-claims}
 
 claims
-: REQUIRED, JSON object: one or more claims with their new value(s)
+
+> REQUIRED, JSON object: one or more claims with their new value(s)
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the claim value(s) changed.
@@ -507,41 +509,47 @@ nested `reason_admin` and/or `reason_user` claims made in
 ### Event-Specific Claims {#credential-change-claims}
 
 credential_type
-: REQUIRED, JSON string: This MUST be one of the following strings, or any other
-credential type supported mutually by the Transmitter and the Receiver.
 
-* `password`
-* `pin`
-* `x509`
-* `fido2-platform`
-* `fido2-roaming`
-* `fido-u2f`
-* `verifiable-credential`
-* `phone-voice`
-* `phone-sms`
-* `app`
+> REQUIRED, JSON string: This MUST be one of the following strings, or any other
+credential type supported mutually by the Transmitter and the Receiver.
+>
+> * `password`
+> * `pin`
+> * `x509`
+> * `fido2-platform`
+> * `fido2-roaming`
+> * `fido-u2f`
+> * `verifiable-credential`
+> * `phone-voice`
+> * `phone-sms`
+> * `app`
 
 change_type
-: REQUIRED, JSON string: This MUST be one of the following strings:
 
-* `create`
-* `revoke`
-* `update`
-* `delete`
+> REQUIRED, JSON string: This MUST be one of the following strings:
+>
+> * `create`
+> * `revoke`
+> * `update`
+> * `delete`
 
 friendly_name
-: OPTIONAL, JSON string: credential friendly name
+
+> OPTIONAL, JSON string: credential friendly name
 
 x509_issuer
-: OPTIONAL, JSON string: issuer of the X.509 certificate as defined in
+
+> OPTIONAL, JSON string: issuer of the X.509 certificate as defined in
 {{RFC5280}}
 
 x509_serial
-: OPTIONAL, JSON string: serial number of the X.509 certificate as defined in
+
+> OPTIONAL, JSON string: serial number of the X.509 certificate as defined in
 {{RFC5280}}
 
 fido2_aaguid
-: OPTIONAL, JSON string: FIDO2 Authenticator Attestation GUID as defined in
+
+> OPTIONAL, JSON string: FIDO2 Authenticator Attestation GUID as defined in
 {{WebAuthn}}
 
 When `event_timestamp` is included, its value MUST represent the time at which
@@ -607,41 +615,44 @@ nested `reason_admin` and/or `reason_user` claims made in
 ### Event-Specific Claims {#assurance-level-change-claims}
 
 namespace:
-: REQUIRED, JSON string: the namespace of the values in the `current_level` and
-`previous_level` claims.
-This string MAY be one of the following strings:
 
-* `RFC8176`: The assurance level values are from the {{RFC8176}} specification
-* `RFC6711`: The assurance level values are from the {{RFC6711}} specification
-* `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}}
+> REQUIRED, JSON string: the namespace of the values in the `current_level` and
+`previous_level` claims. This string MAY be one of the following strings:
+>
+> * `RFC8176`: The assurance level values are from the {{RFC8176}} specification
+> * `RFC6711`: The assurance level values are from the {{RFC6711}} specification
+> * `ISO-IEC-29115`: The assurance level values are from the {{ISO-IEC-29115}}
 specification
-* `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}}
+> * `NIST-IAL`: The assurance level values are from the {{NIST-IDPROOF}}
 specification
-* `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}}
+> * `NIST-AAL`: The assurance level values are from the {{NIST-AUTH}}
 specification
-* `NIST-FAL`: The assurance level values are from the {{NIST-FED}}
+> * `NIST-FAL`: The assurance level values are from the {{NIST-FED}}
 specification
-* Any other value that is an alias for a custom namespace agreed between the
+> * Any other value that is an alias for a custom namespace agreed between the
 Transmitter and the Receiver
 
 current_level
-: REQUIRED, JSON string: The current assurance level, as defined in the
+
+> REQUIRED, JSON string: The current assurance level, as defined in the
 specified `namespace`
 
 previous_level
-: OPTIONAL, JSON string: the previous assurance level, as defined in the
+
+> OPTIONAL, JSON string: the previous assurance level, as defined in the
 specified `namespace`
 If the Transmitter omits this value, the Receiver MUST assume that the previous
 assurance level is unknown to the Transmitter
 
 change_direction
-: OPTIONAL, JSON string: the assurance level increased or decreased
-If the Transmitter has specified the `previous_level`, then the Transmitter
-SHOULD provide a value for this claim.
-If present, this MUST be one of the following strings:
 
-* `increase`
-* `decrease`
+> OPTIONAL, JSON string: the assurance level increased or decreased
+If the Transmitter has specified the `previous_level`, then the Transmitter
+SHOULD provide a value for this claim. If present, this MUST be one of the
+following strings:
+>
+> * `increase`
+> * `decrease`
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the assurance level changed.
@@ -715,19 +726,20 @@ nested `reason_admin` and/or `reason_user` claims made in
 ### Event-Specific Claims {#device-compliance-change-claims}
 
 previous_status
-: REQUIRED, JSON string: the compliance status prior to the change that
-triggered the event
-: This MUST be one of the following strings:
 
-* `compliant`
-* `not-compliant`
+> REQUIRED, JSON string: the compliance status prior to the change that
+triggered the event. This MUST be one of the following strings:
+>
+> * `compliant`
+> * `not-compliant`
 
 current_status
-: REQUIRED, JSON string: the current status that triggered the event
-: This MUST be one of the following strings:
 
-* `compliant`
-* `not-compliant`
+> REQUIRED, JSON string: the current status that triggered the event. This MUST
+be one of the following strings:
+>
+> * `compliant`
+> * `not-compliant`
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the device compliance status changed.
@@ -798,22 +810,26 @@ was established.
 The following optional claims MAY be included in the Session Established event:
 
 fp_ua
-: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
+
+> Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
 not to identify the session, but to present some qualities of the session)
 
 acr
-: The authentication context class reference of the session, as established by
+
+> The authentication context class reference of the session, as established by
 the Transmitter. The value of this field MUST be interpreted in the same way as
 the corresponding field in an OpenID Connect ID Token {{OpenID.Core}}
 
 amr
-: The authentication methods reference of the session, as established by the
+
+> The authentication methods reference of the session, as established by the
 Transmitter. The value of this field MUST be an array of strings, each of which
 MUST be interpreted in the same way as the corresponding field in an OpenID
 Connect ID Token {{OpenID.Core}}
 
 ext_id
-: The external session identifier, which may be used to correlate this session
+
+> The external session identifier, which may be used to correlate this session
 with a broader session (e.g., a federated session established using SAML)
 
 ### Examples {#session-established-examples}
@@ -862,11 +878,13 @@ information for reasons that include:
 The following optional claims MAY be present in a Session Presented event:
 
 fp_ua
-: Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
+
+> Fingerprint of the user agent computed by the Transmitter. (**NOTE**, this is
 not to identify the session, but to present some qualities of the session)
 
 ext_id
-: The external session identifier, which may be used to correlate this session
+
+> The external session identifier, which may be used to correlate this session
 with a broader session (e.g., a federated session established using SAML)
 
 ### Examples {#session-presented-examples}
@@ -921,11 +939,13 @@ connection to insecure pheripheral device, encryption of data or other reasons.
 ### Event Specific Claims {#risk-level-change-event-specific-claims}
 
 risk_reason
-: RECOMMENDED, JSON string: indicates the reason that contributed to the risk
+
+> RECOMMENDED, JSON string: indicates the reason that contributed to the risk
 level changes by the Transmitter.
 
 principal
-: REQUIRED, JSON string: representing the principal entity involved in the
+
+> REQUIRED, JSON string: representing the principal entity involved in the
 observed risk event, as identified by the transmitter. The subject principal can
 be one of the following entities USER, DEVICE, SESSION, TENANT, ORG_UNIT, GROUP,
 or any other entity as defined in Section 2 of {{SSF}}. This claim identifies
@@ -933,11 +953,13 @@ the primary subject associated with the event, and helps to contextualize the
 risk relative to the entity involved.
 
 current_level
-: REQUIRED, JSON string: indicates the current level of the risk for the
+
+> REQUIRED, JSON string: indicates the current level of the risk for the
 subject. Value MUST be one of LOW, MEDIUM, HIGH
 
 previous_level
-: OPTIONAL, JSON string: indicates the previously known level of the risk for
+
+> OPTIONAL, JSON string: indicates the previously known level of the risk for
 the subject. Value MUST be one of LOW, MEDIUM, HIGH. If the Transmitter omits
 this value, the Receiver MUST assume that the previous risk level is unknown to
 the Transmitter.

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -35,7 +35,8 @@ normative:
   RFC8936: # POLL delivery
   SSF:
     target: https://openid.net/specs/openid-sharedsignals-framework-1_0.html
-    title: OpenID Shared Signals and Events Framework Specification 1.0 - draft 03
+    title: OpenID Shared Signals and Events Framework Specification 1.0 - draft
+     03
     author:
       -
         ins: A. Tulshibagwale
@@ -74,9 +75,10 @@ normative:
         ins: A. Tulshibagwale
         name: Atul Tulshibagwale
         org: SGNL
-  RFC9325: # Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
-  RFC6125: # Representation and Verification of Domain-Based Application Service Identity within Internet Public Key
-           # Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)
+  RFC9325: # Recommendations for Secure Use of TLS and DTLS
+  RFC6125: # Representation and Verification of Domain-Based Application
+           # Service Identity within Internet Public Key Infrastructure Using
+           # X.509 (PKIX) Certificates in the Context of TLS
   RFC6750: # The OAuth 2.0 Authorization Framework: Bearer Token Usage
   RFC8414: # OAuth 2.0 Authorization Server Metadata
   RFC6749:
@@ -96,21 +98,38 @@ normative:
       -ins: A. Parecki
 
 --- abstract
-This document defines an interoperability profile for implementations of the Shared Signals Framework (SSF) {{SSF}} and the Continuous Access Evaluation Profile (CAEP) {{CAEP}}. This also profiles The OAuth 2.0 Authorization Framework {{RFC6749}} usage in the context of the SSF framework. The interoperability profile is organized around use-cases that improve security of authenticated sessions. It specifies certain optional elements from within the SSF and CAEP specifications as being required to be supported in order to be considered as an interoperable implementation.
+This document defines an interoperability profile for implementations of the
+Shared Signals Framework (SSF) {{SSF}} and the Continuous Access Evaluation
+Profile (CAEP) {{CAEP}}. This also profiles The OAuth 2.0 Authorization
+Framework {{RFC6749}} usage in the context of the SSF framework. The
+interoperability profile is organized around use-cases that improve security
+of authenticated sessions. It specifies certain optional elements from within
+the SSF and CAEP specifications as being required to be supported in order to
+be considered as an interoperable implementation.
 
-Interoperability between SSF and CAEP, leveraging OAuth {{RFC6749}} provides greater assurance to implementers that their implementations will work out of the box with others.
+Interoperability between SSF and CAEP, leveraging OAuth {{RFC6749}} provides
+greater assurance to implementers that their implementations will work out of
+the box with others.
 
 --- middle
 
 # Introduction {#introduction}
 
-SSF and CAEP together enable improved session security outcomes. This specification defines the minimum required features from SSF and CAEP that an implementation MUST offer in order to be considered as an interoperable implementation. This document defines specific use cases. An implementation MAY support only a subset of the use cases defined herein, and SHALL be considered an interoperable implementation for the specific use-cases it supports. The following use-cases are considered as a part of this specification:
+SSF and CAEP together enable improved session security outcomes. This
+specification defines the minimum required features from SSF and CAEP that an
+implementation MUST offer in order to be considered as an interoperable
+implementation. This document defines specific use cases. An implementation MAY
+support only a subset of the use cases defined herein, and SHALL be considered
+an interoperable implementation for the specific use-cases it supports. The
+following use-cases are considered as a part of this specification:
 
 Session Revocation
-: A SSF Transmitter or Receiver is able to respectively generate or respond to the CAEP session-revoked event
+: A SSF Transmitter or Receiver is able to respectively generate or respond to
+the CAEP session-revoked event
 
 Credential Change
-: A SSF Transmitter or Receiver is able to respectively generate or respond to the CAEP credential-change event
+: A SSF Transmitter or Receiver is able to respectively generate or respond to
+the CAEP credential-change event
 
 ## Notational Conventions
 
@@ -122,13 +141,19 @@ they appear in all capitals, as shown here.
 
 # Common Requirements {#common-requirements}
 
-The following requirements are common across all use-cases defined in this document.
+The following requirements are common across all use-cases defined in this
+document.
 
 ## Network layer protection
 
-* The SSF transmitter MUST offer TLS protected endpoints and MUST establish connections to other servers using TLS. TLS connections MUST be set up to use TLS version 1.2 or later.
-* The SSF transmitter MUST follow the recommendations for Secure Use of Transport Layer Security in [RFC9325]{{RFC9325}}.
-* The SSF receiver MUST perform a TLS server certificate signature checks, chain of trust validations, expiry and revocation status checks before calling the SSF transmitter APIs, as per [RFC6125]{{RFC6125}}.
+* The SSF transmitter MUST offer TLS protected endpoints and MUST establish
+connections to other servers using TLS. TLS connections MUST be set up to use
+TLS version 1.2 or later.
+* The SSF transmitter MUST follow the recommendations for Secure Use of
+Transport Layer Security in [RFC9325]{{RFC9325}}.
+* The SSF receiver MUST perform a TLS server certificate signature checks, chain
+of trust validations, expiry and revocation status checks before calling the SSF
+transmitter APIs, as per [RFC6125]{{RFC6125}}.
 
 ## CAEP specification version
 
@@ -140,37 +165,50 @@ Transmitters MUST implement the following features:
 
 ### Spec Version {#spec-version}
 
-The Transmitter Configuration Metadata MUST have a `spec_version` field, and its value MUST be `1_0-ID2` or greater
+The Transmitter Configuration Metadata MUST have a `spec_version` field, and its
+value MUST be `1_0-ID2` or greater
 
 ### Delivery Method {#delivery-method}
 
-The Transmitter Configuration Metadata MUST include the `delivery_methods_supported` field.
+The Transmitter Configuration Metadata MUST include the
+`delivery_methods_supported` field.
 
 ### JWKS URI {#jwks-uri}
 
-The Transmitter Configuration Metadata MUST include the `jwks_uri` field, and its value MUST provide the current signing key of the Transmitter.
+The Transmitter Configuration Metadata MUST include the `jwks_uri` field, and
+its value MUST provide the current signing key of the Transmitter.
 
 ### Configuration Endpoint {#configuration-endpoint}
 
-The Transmitter Configuration Metadata MUST include the `configuration_endpoint` field. The specified endpoint MUST support the `POST` method in order to be able to create a stream.
+The Transmitter Configuration Metadata MUST include the `configuration_endpoint`
+field. The specified endpoint MUST support the `POST` method in order to be able
+to create a stream.
 
 ### Status Endpoint {#status-endpoint}
 
-The Transmitter Configuration Metadata MUST include the `status_endpoint` field. The specified endpoint MUST support the `GET` and `POST` methods in order to get and update the stream status respectively. The Transmitter MUST support the following values in an Update Stream Status request:
+The Transmitter Configuration Metadata MUST include the `status_endpoint` field.
+The specified endpoint MUST support the `GET` and `POST` methods in order to get
+and update the stream status respectively. The Transmitter MUST support the
+following values in an Update Stream Status request:
 
 * `enabled`
 * `paused`
 * `disabled`
 
-For streams that are `paused`, the Transmitter MUST specify (offline) the resource constraints on how many events it can keep, or for how long. The way a Transmitter specifies this information is outside the scope of the SSF spec.
+For streams that are `paused`, the Transmitter MUST specify (offline) the
+resource constraints on how many events it can keep, or for how long. The way a
+Transmitter specifies this information is outside the scope of the SSF spec.
 
 ### Verification Endpoint {#verification-endpoint}
 
-The Transmitter Configuration Metadata MUST include the `verification_endpoint` field. The specified endpoint MUST provide a way to request verification events to be sent.
+The Transmitter Configuration Metadata MUST include the `verification_endpoint`
+field. The specified endpoint MUST provide a way to request verification events
+to be sent.
 
 ### Authorization Schemes
 
-The Transmitter Configuration Metadata MUST include the `authorization_schemes` field and its value MUST include the value
+The Transmitter Configuration Metadata MUST include the `authorization_schemes`
+field and its value MUST include the value
 
 ~~~json
 {
@@ -184,28 +222,37 @@ In all streams created by the Transmitter, the following MUST be true:
 
 #### Delivery {#common-delivery}
 
-A Transmitter MUST be able to accept a Create Stream request that includes either of the following delivery methods:
+A Transmitter MUST be able to accept a Create Stream request that includes
+either of the following delivery methods:
 
 * urn:ietf:rfc:8935 (Push)
 * urn:ietf:rfc:8936 (Poll)
 
-The `delivery` field MUST be present in the Configuration of any Stream generated by the Transmitter, and its value MUST include one of the two delivery methods listed above.
+The `delivery` field MUST be present in the Configuration of any Stream
+generated by the Transmitter, and its value MUST include one of the two delivery
+methods listed above.
 
 #### Stream Control
 
 The following Stream Configuration API Methods MUST be supported:
 
 **Creating a Stream**
-: Receivers MUST be able to create a Stream with the Transmitter using valid authorization with the Transmitter. The Transmitter MAY support multiple streams with the same Receiver
+: Receivers MUST be able to create a Stream with the Transmitter using valid
+authorization with the Transmitter. The Transmitter MAY support multiple streams
+with the same Receiver
 
 **Reading Stream Configuration**
-: A Receiver MUST be able to obtain current Stream configuration from the Transmitter by providing a valid authorization
+: A Receiver MUST be able to obtain current Stream configuration from the
+Transmitter by providing a valid authorization
 
 **Getting the Stream Status**
-: A Receiver MUST be able to obtain the current Stream status from the Transmitter by providing a valid authorization
+: A Receiver MUST be able to obtain the current Stream status from the
+Transmitter by providing a valid authorization
 
 **Stream Verification**
-: A Receiver MUST be able to verify the liveness of the Stream by requesting that the Transmitter send it a Stream Verificaiton event by providing a valid authorization
+: A Receiver MUST be able to verify the liveness of the Stream by requesting
+that the Transmitter send it a Stream Verificaiton event by providing a valid
+authorization
 
 ## Receivers {#common-receivers}
 
@@ -213,57 +260,85 @@ Receivers MUST implement the following features:
 
 ### Delivery Methods {#common-receiver-delivery}
 
-Receivers MUST be able to accept events using the Push-Based Security Event Token (SET) Delivery Using HTTP {{RFC8935}} specification and the Poll-Based Security Event Token (SET) Delivery Using HTTP {{RFC8936}} specification.
+Receivers MUST be able to accept events using the Push-Based Security Event
+Token (SET) Delivery Using HTTP {{RFC8935}} specification and the Poll-Based
+Security Event Token (SET) Delivery Using HTTP {{RFC8936}} specification.
 
 ### Implicitly Added Subjects {#common-receiver-subjects}
 
-Receivers MUST assume that all subjects are implicitly included in a Stream, without any `AddSubject` method invocations.
+Receivers MUST assume that all subjects are implicitly included in a Stream,
+without any `AddSubject` method invocations.
 
 ## Event Subjects {#common-event-subjects}
 
-The following subject identifier formats from "Subject Identifiers for Security Event Tokens" {{RFC9493}} MUST be supported:
+The following subject identifier formats from "Subject Identifiers for Security
+Event Tokens" {{RFC9493}} MUST be supported:
 
 * `email`
 * `iss_sub`
 * `opaque` (for the Verification event only)
 
-Receivers MUST be prepared to accept events with any of the subject identifier formats specified in this section. Transmitters MUST be able to send events with at least one of subject identifier formats specified in this section.
+Receivers MUST be prepared to accept events with any of the subject identifier
+formats specified in this section. Transmitters MUST be able to send events with
+at least one of subject identifier formats specified in this section.
 
 ## Event Signatures
 
-All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bit keys.
+All events MUST be signed using the `RS256` algorithm using a minimum of
+2048-bit keys.
 
 ## OAuth Service
 
 ### Authorization Server
 
-* MAY distribute discovery metadata (such as the authorization endpoint) via the metadata document as specified in [RFC8414]{{RFC8414}}
-* MUST support at least one of the following to obtain a short-lived access token. For example, a short lived access token could be defined as one in which the value of the `exp` claim is not longer than 60 mins after `nbf` claim. Please refer to Access token lifetimes in the security considerations of {{FAPI}} for additional considerations.
+* MAY distribute discovery metadata (such as the authorization endpoint) via the
+metadata document as specified in [RFC8414]{{RFC8414}}
+* MUST support at least one of the following to obtain a short-lived access
+token. For example, a short lived access token could be defined as one in which
+the value of the `exp` claim is not longer than 60 mins after `nbf` claim.
+Please efer to Access token lifetimes in the security considerations of {{FAPI}}
+for additional considerations.
 * client credential grant flow {{RFC6749}} section 4.4
 * authorization code flow {{RFC6749}} section 4.1
 
 ### OAuth Scopes
 
-Depending on the features supported by the OAuth service and the SSF APIs, the client SHALL discover the OAuth scopes as follows:
+Depending on the features supported by the OAuth service and the SSF APIs, the
+client SHALL discover the OAuth scopes as follows:
 
-1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{OPRM}} then the client MUST obtain the required scopes by using it.
+1. If the Resource Server, hosting SSF configuration APIs, supports OAuth
+Protected Resource Metadata {{OPRM}} then the client MUST obtain the required
+scopes by using it.
 
-2. If the Resource Server does not support {{OPRM}}, then the following scopes MUST be supported -
+2. If the Resource Server does not support {{OPRM}}, then the following scopes
+MUST be supported -
 
-* An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of `ssf`
-* All the SSF stream configuration management API operations MUST accept `ssf.manage` scope
-* All the SSF stream configuration Read API operations MUST accept `ssf.read` scope
-* Authorization server MAY postfix scope names with more granular operations eg. `ssf.manage.create`, `ssf.manage.update` etc.
-* Transmitter managed poll endpoint MAY support the postfix scopes in the same nomenclature as `ssf.manage.poll`
+* An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF
+Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of
+`ssf`
+* All the SSF stream configuration management API operations MUST accept
+`ssf.manage` scope
+* All the SSF stream configuration Read API operations MUST accept `ssf.read`
+scope
+* Authorization server MAY postfix scope names with more granular operations eg.
+`ssf.manage.create`, `ssf.manage.update` etc.
+* Transmitter managed poll endpoint MAY support the postfix scopes in the same
+nomenclature as `ssf.manage.poll`
 
 ### The SSF Transmitter as a Resource Server
 
-* MUST accept access tokens in the HTTP header as in Section 2.1 of OAuth 2.0 Bearer Token Usage [RFC6750]{{RFC6750}}
-* MUST NOT accept access tokens in the query parameters stated in Section 2.3 of OAuth 2.0 Bearer Token Usage [RFC6750]{{RFC6750}}
-* MUST verify the validity, integrity, expiration and revocation status of access tokens
-* MUST verify that the authorization represented by the access token is sufficient for the requested resource access.
-* If the access token is not sufficient for the requested action, the Resource server MUST return errors as per section 3.1 of [RFC6750]{{RFC6750}}
-* MAY publish the {{OPRM}} to describe the metadata needed to interact with the protected resource.
+* MUST accept access tokens in the HTTP header as in Section 2.1 of OAuth 2.0
+Bearer Token Usage [RFC6750]{{RFC6750}}
+* MUST NOT accept access tokens in the query parameters stated in Section 2.3 of
+OAuth 2.0 Bearer Token Usage [RFC6750]{{RFC6750}}
+* MUST verify the validity, integrity, expiration and revocation status of
+access tokens
+* MUST verify that the authorization represented by the access token is
+sufficient for the requested resource access.
+* If the access token is not sufficient for the requested action, the Resource
+server MUST return errors as per section 3.1 of [RFC6750]{{RFC6750}}
+* MAY publish the {{OPRM}} to describe the metadata needed to interact with the
+protected resource.
 
 ## Security Event Token
 
@@ -273,29 +348,38 @@ The "events" claim of the SET MUST contain only one event.
 
 # Use Cases
 
-Implementations MAY choose to support one or more of the following use-cases in order to be considered interoperable implementations
+Implementations MAY choose to support one or more of the following use-cases in
+order to be considered interoperable implementations
 
 ## Session Revocation / Logout
 
-In order to support session revocation or logout, implementations MUST support the CAEP event type `session-revoked`. The `reason_admin` field of the event MUST be populated with a non-empty value.
+In order to support session revocation or logout, implementations MUST support
+the CAEP event type `session-revoked`. The `reason_admin` field of the event
+MUST be populated with a non-empty value.
 
 ## Credential Change
 
-In order to support notifying and responding to credential changes, implementations MUST support the CAEP event type `credential-change`.
-Within the `credential-change` event, implementations MUST support the following field values:
+In order to support notifying and responding to credential changes,
+implementations MUST support the CAEP event type `credential-change`.
+Within the `credential-change` event, implementations MUST support the following
+field values:
 
 `change_type`
-: Receivers MUST interpret all allowable values of this field. Transmitters MAY generate any allowable value of this field
+: Receivers MUST interpret all allowable values of this field. Transmitters MAY
+generate any allowable value of this field
 
 `credential_type`
-: Receivers MUST interpret all allowable values of this field. Transmitters MAY generate any allowable value of this field
+: Receivers MUST interpret all allowable values of this field. Transmitters MAY
+generate any allowable value of this field
 
 `reason_admin`
 : Transmitters MUST populate this value with a non-empty string
 
 # Security Considerations
 
-There are no additional security considerations that arise from this document. These are covered in the "Security Considerations" sections of {{SSF}} and {{CAEP}} specifications.
+There are no additional security considerations that arise from this document.
+These are covered in the "Security Considerations" sections of {{SSF}} and
+{{CAEP}} specifications.
 
 --- back
 
@@ -309,9 +393,34 @@ specification.
 
 Copyright (c) 2024 The OpenID Foundation.
 
-The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer, or other interested party a non-exclusive, royalty free, worldwide copyright license to reproduce, prepare derivative works from, distribute, perform and display, this Implementers Draft or Final Specification solely for the purposes of (i) developing specifications, and (ii) implementing Implementers Drafts and Final Specifications based on such documents, provided that attribution be made to the OIDF as the source of the material, but that such attribution does not indicate an endorsement by the OIDF.
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright
+license to reproduce, prepare derivative works from, distribute, perform and
+display, this Implementers Draft or Final Specification solely for the purposes
+of (i) developing specifications, and (ii) implementing Implementers Drafts and
+Final Specifications based on such documents, provided that attribution be made
+to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
 
-The technology described in this specification was made available from contributions from various sources, including members of the OpenID Foundation and others. Although the OpenID Foundation has taken steps to help ensure that the technology is available for distribution, it takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this specification or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any independent effort to identify any such rights. The OpenID Foundation and the contributors to this specification make no (and hereby expressly disclaim any) warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to this specification, and the entire risk as to implementing this specification is assumed by the implementer. The OpenID Intellectual Property Rights policy requires contributors to offer a patent promise not to assert certain patent claims against other contributors and against implementers. The OpenID Foundation invites any interested party to bring to its attention any copyrights, patents, patent applications, or other proprietary rights that may cover technology that may be required to practice this specification.
+The technology described in this specification was made available from
+contributions from various sources, including members of the OpenID Foundation
+and others. Although the OpenID Foundation has taken steps to help ensure that
+the technology is available for distribution, it takes no position regarding the
+validity or scope of any intellectual property or other rights that might be
+claimed to pertain to the implementation or use of the technology described in
+this specification or the extent to which any license under such rights might or
+might not be available; neither does it represent that it has made any
+independent effort to identify any such rights. The OpenID Foundation and the
+contributors to this specification make no (and hereby expressly disclaim any)
+warranties (express, implied, or otherwise), including implied warranties of
+merchantability, non-infringement, fitness for a particular purpose, or title,
+related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy requires contributors to offer a patent promise not to assert
+certain patent claims against other contributors and against implementers. The
+OpenID Foundation invites any interested party to bring to its attention any
+copyrights, patents, patent applications, or other proprietary rights that may
+cover technology that may be required to practice this specification.
 
 # Document History
 

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -1,8 +1,8 @@
 ---
-title: CAEP Interoperability Profile 1.0 - draft 00
+title: CAEP Interoperability Profile 1.0 - draft 01
 abbrev: caep-interop
 docname: caep-interoperability-profile-1_0
-date: 2025-05-22
+date: 2025-05-29
 
 ipr: none
 cat: std
@@ -425,6 +425,10 @@ cover technology that may be required to practice this specification.
 # Document History
 
   [[ To be removed from the final specification ]]
+
+-01
+
+* Cleaned up markdown (#91)
 
 -00
   

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -1,5 +1,5 @@
 ---
-title: CAEP Interoperability Profile 1.0 - draft 01
+title: CAEP Interoperability Profile 1.0 - draft 00
 abbrev: caep-interop
 docname: caep-interoperability-profile-1_0
 date: 2025-05-22
@@ -429,7 +429,3 @@ cover technology that may be required to practice this specification.
 -00
   
 * Initial draft
-
--01
-
-* Formatting adjustments

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -29,7 +29,7 @@ author:
 
 normative:
   RFC2119:
-  RFC8174: 
+  RFC8174:
   RFC9493: # Subject Identifier Formats for SETs
   RFC8935: # Push delivery
   RFC8936: # POLL delivery
@@ -75,7 +75,7 @@ normative:
         name: Atul Tulshibagwale
         org: SGNL
   RFC9325: # Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
-  RFC6125: # Representation and Verification of Domain-Based Application Service Identity within Internet Public Key 
+  RFC6125: # Representation and Verification of Domain-Based Application Service Identity within Internet Public Key
            # Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)
   RFC6750: # The OAuth 2.0 Authorization Framework: Bearer Token Usage
   RFC8414: # OAuth 2.0 Authorization Server Metadata
@@ -95,15 +95,15 @@ normative:
       -ins: P. Hunt
       -ins: A. Parecki
 
-
 --- abstract
-This document defines an interoperability profile for implementations of the Shared Signals Framework (SSF) {{SSF}} and the Continuous Access Evaluation Profile (CAEP) {{CAEP}}. This also profiles The OAuth 2.0 Authorization Framework {{RFC6749}} usage in the context of the SSF framework. The interoperability profile is organized around use-cases that improve security of authenticated sessions. It specifies certain optional elements from within the SSF and CAEP specifications as being required to be supported in order to be considered as an interoperable implementation. 
+This document defines an interoperability profile for implementations of the Shared Signals Framework (SSF) {{SSF}} and the Continuous Access Evaluation Profile (CAEP) {{CAEP}}. This also profiles The OAuth 2.0 Authorization Framework {{RFC6749}} usage in the context of the SSF framework. The interoperability profile is organized around use-cases that improve security of authenticated sessions. It specifies certain optional elements from within the SSF and CAEP specifications as being required to be supported in order to be considered as an interoperable implementation.
 
 Interoperability between SSF and CAEP, leveraging OAuth {{RFC6749}} provides greater assurance to implementers that their implementations will work out of the box with others.
 
 --- middle
 
 # Introduction {#introduction}
+
 SSF and CAEP together enable improved session security outcomes. This specification defines the minimum required features from SSF and CAEP that an implementation MUST offer in order to be considered as an interoperable implementation. This document defines specific use cases. An implementation MAY support only a subset of the use cases defined herein, and SHALL be considered an interoperable implementation for the specific use-cases it supports. The following use-cases are considered as a part of this specification:
 
 Session Revocation
@@ -121,32 +121,41 @@ described in BCP 14 {{RFC2119}} {{RFC8174}} when, and only when,
 they appear in all capitals, as shown here.
 
 # Common Requirements {#common-requirements}
+
 The following requirements are common across all use-cases defined in this document.
 
 ## Network layer protection
+
 * The SSF transmitter MUST offer TLS protected endpoints and MUST establish connections to other servers using TLS. TLS connections MUST be set up to use TLS version 1.2 or later.
 * The SSF transmitter MUST follow the recommendations for Secure Use of Transport Layer Security in [RFC9325]{{RFC9325}}.
 * The SSF receiver MUST perform a TLS server certificate signature checks, chain of trust validations, expiry and revocation status checks before calling the SSF transmitter APIs, as per [RFC6125]{{RFC6125}}.
 
 ## CAEP specification version
+
 This specification supports CAEP {{CAEP}} events from Implementer's Draft 2
 
 ## Transmitters {#common-transmitters}
+
 Transmitters MUST implement the following features:
 
 ### Spec Version {#spec-version}
+
 The Transmitter Configuration Metadata MUST have a `spec_version` field, and its value MUST be `1_0-ID2` or greater
 
 ### Delivery Method {#delivery-method}
+
 The Transmitter Configuration Metadata MUST include the `delivery_methods_supported` field.
 
 ### JWKS URI {#jwks-uri}
+
 The Transmitter Configuration Metadata MUST include the `jwks_uri` field, and its value MUST provide the current signing key of the Transmitter.
 
 ### Configuration Endpoint {#configuration-endpoint}
+
 The Transmitter Configuration Metadata MUST include the `configuration_endpoint` field. The specified endpoint MUST support the `POST` method in order to be able to create a stream.
 
 ### Status Endpoint {#status-endpoint}
+
 The Transmitter Configuration Metadata MUST include the `status_endpoint` field. The specified endpoint MUST support the `GET` and `POST` methods in order to get and update the stream status respectively. The Transmitter MUST support the following values in an Update Stream Status request:
 
 * `enabled`
@@ -156,9 +165,11 @@ The Transmitter Configuration Metadata MUST include the `status_endpoint` field.
 For streams that are `paused`, the Transmitter MUST specify (offline) the resource constraints on how many events it can keep, or for how long. The way a Transmitter specifies this information is outside the scope of the SSF spec.
 
 ### Verification Endpoint {#verification-endpoint}
+
 The Transmitter Configuration Metadata MUST include the `verification_endpoint` field. The specified endpoint MUST provide a way to request verification events to be sent.
 
 ### Authorization Schemes
+
 The Transmitter Configuration Metadata MUST include the `authorization_schemes` field and its value MUST include the value
 
 ~~~json
@@ -168,9 +179,11 @@ The Transmitter Configuration Metadata MUST include the `authorization_schemes` 
 ~~~
 
 ### Streams {#common-stream-configuration}
+
 In all streams created by the Transmitter, the following MUST be true:
 
 #### Delivery {#common-delivery}
+
 A Transmitter MUST be able to accept a Create Stream request that includes either of the following delivery methods:
 
 * urn:ietf:rfc:8935 (Push)
@@ -179,6 +192,7 @@ A Transmitter MUST be able to accept a Create Stream request that includes eithe
 The `delivery` field MUST be present in the Configuration of any Stream generated by the Transmitter, and its value MUST include one of the two delivery methods listed above.
 
 #### Stream Control
+
 The following Stream Configuration API Methods MUST be supported:
 
 **Creating a Stream**
@@ -194,15 +208,19 @@ The following Stream Configuration API Methods MUST be supported:
 : A Receiver MUST be able to verify the liveness of the Stream by requesting that the Transmitter send it a Stream Verificaiton event by providing a valid authorization
 
 ## Receivers {#common-receivers}
+
 Receivers MUST implement the following features:
 
 ### Delivery Methods {#common-receiver-delivery}
+
 Receivers MUST be able to accept events using the Push-Based Security Event Token (SET) Delivery Using HTTP {{RFC8935}} specification and the Poll-Based Security Event Token (SET) Delivery Using HTTP {{RFC8936}} specification.
 
 ### Implicitly Added Subjects {#common-receiver-subjects}
+
 Receivers MUST assume that all subjects are implicitly included in a Stream, without any `AddSubject` method invocations.
 
 ## Event Subjects {#common-event-subjects}
+
 The following subject identifier formats from "Subject Identifiers for Security Event Tokens" {{RFC9493}} MUST be supported:
 
 * `email`
@@ -212,29 +230,34 @@ The following subject identifier formats from "Subject Identifiers for Security 
 Receivers MUST be prepared to accept events with any of the subject identifier formats specified in this section. Transmitters MUST be able to send events with at least one of subject identifier formats specified in this section.
 
 ## Event Signatures
+
 All events MUST be signed using the `RS256` algorithm using a minimum of 2048-bit keys.
 
 ## OAuth Service
 
 ### Authorization Server
+
 * MAY distribute discovery metadata (such as the authorization endpoint) via the metadata document as specified in [RFC8414]{{RFC8414}}
-* MUST support at least one of the following to obtain a short-lived access token. For example, a short lived access token could be defined as one in which the value of the `exp` claim is not longer than 60 mins after `nbf` claim. Please refer to Access token lifetimes in the security considerations of {{FAPI}} for additional considerations. 
-  - client credential grant flow {{RFC6749}} section 4.4
-  - authorization code flow {{RFC6749}} section 4.1
+* MUST support at least one of the following to obtain a short-lived access token. For example, a short lived access token could be defined as one in which the value of the `exp` claim is not longer than 60 mins after `nbf` claim. Please refer to Access token lifetimes in the security considerations of {{FAPI}} for additional considerations.
+* client credential grant flow {{RFC6749}} section 4.4
+* authorization code flow {{RFC6749}} section 4.1
 
 ### OAuth Scopes
+
 Depending on the features supported by the OAuth service and the SSF APIs, the client SHALL discover the OAuth scopes as follows:
 
 1. If the Resource Server, hosting SSF configuration APIs, supports OAuth Protected Resource Metadata {{OPRM}} then the client MUST obtain the required scopes by using it.
 
 2. If the Resource Server does not support {{OPRM}}, then the following scopes MUST be supported -
-   - An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of `ssf`
-   - All the SSF stream configuration management API operations MUST accept `ssf.manage` scope
-   - All the SSF stream configuration Read API operations MUST accept `ssf.read` scope
-   - Authorization server MAY postfix scope names with more granular operations eg. `ssf.manage.create`, `ssf.manage.update` etc.
-   - Transmitter managed poll endpoint MAY support the postfix scopes in the same nomenclature as `ssf.manage.poll`
+
+* An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of `ssf`
+* All the SSF stream configuration management API operations MUST accept `ssf.manage` scope
+* All the SSF stream configuration Read API operations MUST accept `ssf.read` scope
+* Authorization server MAY postfix scope names with more granular operations eg. `ssf.manage.create`, `ssf.manage.update` etc.
+* Transmitter managed poll endpoint MAY support the postfix scopes in the same nomenclature as `ssf.manage.poll`
 
 ### The SSF Transmitter as a Resource Server
+
 * MUST accept access tokens in the HTTP header as in Section 2.1 of OAuth 2.0 Bearer Token Usage [RFC6750]{{RFC6750}}
 * MUST NOT accept access tokens in the query parameters stated in Section 2.3 of OAuth 2.0 Bearer Token Usage [RFC6750]{{RFC6750}}
 * MUST verify the validity, integrity, expiration and revocation status of access tokens
@@ -245,15 +268,19 @@ Depending on the features supported by the OAuth service and the SSF APIs, the c
 ## Security Event Token
 
 ### The "events" claim
+
 The "events" claim of the SET MUST contain only one event.
 
 # Use Cases
+
 Implementations MAY choose to support one or more of the following use-cases in order to be considered interoperable implementations
 
 ## Session Revocation / Logout
+
 In order to support session revocation or logout, implementations MUST support the CAEP event type `session-revoked`. The `reason_admin` field of the event MUST be populated with a non-empty value.
 
 ## Credential Change
+
 In order to support notifying and responding to credential changes, implementations MUST support the CAEP event type `credential-change`.
 Within the `credential-change` event, implementations MUST support the following field values:
 
@@ -267,6 +294,7 @@ Within the `credential-change` event, implementations MUST support the following
 : Transmitters MUST populate this value with a non-empty string
 
 # Security Considerations
+
 There are no additional security considerations that arise from this document. These are covered in the "Security Considerations" sections of {{SSF}} and {{CAEP}} specifications.
 
 --- back
@@ -288,6 +316,7 @@ The technology described in this specification was made available from contribut
 # Document History
 
   [[ To be removed from the final specification ]]
-  -00
+
+-00
   
-  * Initial draft
+* Initial draft

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -313,15 +313,15 @@ scopes by using it.
 * If the Resource Server does not support {{OPRM}}, then the following scopes
 MUST be supported -
 
-  * An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF
-  Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of
-  `ssf`
+  * An OAuth {{RFC6749}} authorization server that is used to issue tokens to
+  SSF Receivers, MUST reserve the scopes for the SSF endpoints with the prefix
+  of `ssf`
   * All the SSF stream configuration management API operations MUST accept
   `ssf.manage` scope
   * All the SSF stream configuration Read API operations MUST accept `ssf.read`
   scope
-  * Authorization server MAY postfix scope names with more granular operations eg.
-  `ssf.manage.create`, `ssf.manage.update` etc.
+  * Authorization server MAY postfix scope names with more granular operations
+  eg. `ssf.manage.create`, `ssf.manage.update` etc.
   * Transmitter managed poll endpoint MAY support the postfix scopes in the same
   nomenclature as `ssf.manage.poll`
 

--- a/openid-caep-interoperability-profile-1_0.md
+++ b/openid-caep-interoperability-profile-1_0.md
@@ -1,8 +1,8 @@
 ---
-title: CAEP Interoperability Profile 1.0 - draft 00
+title: CAEP Interoperability Profile 1.0 - draft 01
 abbrev: caep-interop
 docname: caep-interoperability-profile-1_0
-date: 2024-06-25
+date: 2025-05-22
 
 ipr: none
 cat: std
@@ -298,32 +298,32 @@ token. For example, a short lived access token could be defined as one in which
 the value of the `exp` claim is not longer than 60 mins after `nbf` claim.
 Please efer to Access token lifetimes in the security considerations of {{FAPI}}
 for additional considerations.
-* client credential grant flow {{RFC6749}} section 4.4
-* authorization code flow {{RFC6749}} section 4.1
+  * client credential grant flow {{RFC6749}} section 4.4
+  * authorization code flow {{RFC6749}} section 4.1
 
 ### OAuth Scopes
 
 Depending on the features supported by the OAuth service and the SSF APIs, the
 client SHALL discover the OAuth scopes as follows:
 
-1. If the Resource Server, hosting SSF configuration APIs, supports OAuth
+* If the Resource Server, hosting SSF configuration APIs, supports OAuth
 Protected Resource Metadata {{OPRM}} then the client MUST obtain the required
 scopes by using it.
 
-2. If the Resource Server does not support {{OPRM}}, then the following scopes
+* If the Resource Server does not support {{OPRM}}, then the following scopes
 MUST be supported -
 
-* An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF
-Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of
-`ssf`
-* All the SSF stream configuration management API operations MUST accept
-`ssf.manage` scope
-* All the SSF stream configuration Read API operations MUST accept `ssf.read`
-scope
-* Authorization server MAY postfix scope names with more granular operations eg.
-`ssf.manage.create`, `ssf.manage.update` etc.
-* Transmitter managed poll endpoint MAY support the postfix scopes in the same
-nomenclature as `ssf.manage.poll`
+  * An OAuth {{RFC6749}} authorization server that is used to issue tokens to SSF
+  Receivers, MUST reserve the scopes for the SSF endpoints with the prefix of
+  `ssf`
+  * All the SSF stream configuration management API operations MUST accept
+  `ssf.manage` scope
+  * All the SSF stream configuration Read API operations MUST accept `ssf.read`
+  scope
+  * Authorization server MAY postfix scope names with more granular operations eg.
+  `ssf.manage.create`, `ssf.manage.update` etc.
+  * Transmitter managed poll endpoint MAY support the postfix scopes in the same
+  nomenclature as `ssf.manage.poll`
 
 ### The SSF Transmitter as a Resource Server
 
@@ -429,3 +429,7 @@ cover technology that may be required to practice this specification.
 -00
   
 * Initial draft
+
+-01
+
+* Formatting adjustments

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1,8 +1,8 @@
 ---
-title: OpenID Shared Signals Framework Specification 1.0 - draft 22
+title: OpenID Shared Signals Framework Specification 1.0 - draft 23
 abbrev: SharedSignals
 docname: openid-sharedsignals-framework-1_0
-date: 2025-05-22
+date: 2025-05-29
 
 ipr: none
 cat: std
@@ -489,7 +489,10 @@ on this subject. The Shared Signals Framework requires further restrictions:
 The signature key can be obtained through "jwks_uri", see {{discovery}}.
 
 ### SSF Prescriptive SETs {#prescriptive-sets}
-The Shared Signals Framework allows each deployment or integration to define its own event processing behaviors, ranging from informational input to additional processing needed, to mandatory enforcement.
+
+The Shared Signals Framework allows each deployment or integration to define its
+own event processing behaviors, ranging from informational input to additional
+processing needed, to mandatory enforcement.
 
 ### The "iss" Claim {#iss-claim}
 
@@ -2568,6 +2571,12 @@ the technology is available for distribution, it takes no position regarding the
 # Document History
 
   [[ To be removed from the final specification ]]
+
+-23
+
+* Cleaned up markdown (#91)
+* Added language to allow implementations to define their own processing
+behavior for SETS (#255)
 
 -20
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -416,7 +416,6 @@ ip-addresses
 
 > REQUIRED. The array of IP addresses of the subject as observed by the Transmitter. The value MUST be in the format of an array of strings, each one of which represents the {{RFC4001}} string representation of an IP address.
 
-
 The "IP addresses" Subject Identifier Format is identified by the name
 "ip-addresses".
 
@@ -1170,7 +1169,6 @@ TODO: consider adding a IANA Registry for stream configuration metadata, similar
 to Section 7.1.1 of {{RFC8414}}. This would allow other specs to add to
 the stream configuration.
 
-
 #### Creating a Stream {#creating-a-stream}
 
 In order to communicate events from a Transmitter to a Receiver, a Receiver
@@ -1263,7 +1261,6 @@ Content-Type: application/json
 
 Errors are signaled with HTTP status codes as follows:
 
-
 | Code | Description |
 |------|-------------|
 | 400  | if the request cannot be parsed |
@@ -1271,7 +1268,6 @@ Errors are signaled with HTTP status codes as follows:
 | 403  | if the Event Receiver is not allowed to create a stream |
 | 409  | if the Transmitter does not support multiple streams per Receiver |
 {: title="Create Stream Errors" #tablecreatestream}
-
 
 ##### Validating a Stream Creation Response
 
@@ -1469,7 +1465,6 @@ Cache-Control: no-store
 
 Errors are signaled with HTTP status codes as follows:
 
-
 | Code | Description |
 |------|-------------|
 | 401  | if authorization failed or it is missing |
@@ -1556,7 +1551,6 @@ Cache-Control: no-store
 {: title="Example: Update Stream Configuration Response" #figupdateconfigresp}
 
 Pending conditions or errors are signaled with HTTP status codes as follows:
-
 
 | Code | Description |
 |------|-------------|
@@ -1879,7 +1873,6 @@ Errors are signaled with HTTP status codes as follows:
 | 404  | if there is no Event Stream with the given "stream_id" for this Event Receiver |
 {: title="Update Stream Status Errors" #tabupdatestatus}
 
-
 Examples:
 
 1. If a Receiver makes a request to update a stream status, and the Transmitter is
@@ -2140,7 +2133,6 @@ not requested by the Event Receiver.
 
 A Transmitter MAY respond to Verification Event requests even if the event is not present in the `events_supported`, `events_requested` and / or `events_delivered` fields in the Stream Configuration ({{stream-config}}).
 
-
 #### Verification Event {#verification-event}
 
 The Verification Event is an SSF event with the event type: "https://schemas.openid.net/secevent/ssf/event-type/verification". The event contains the following attribute:
@@ -2330,7 +2322,6 @@ return a "204" response even if they will not actually send any events related
 to the subject, and Event Receivers MUST NOT assume that a 204 response means
 that they will receive events related to the subject.
 
-
 ## Information Harvesting {#management-sec-information-harvesting}
 
 SETs may contain personally identifiable information (PII) or other non-public
@@ -2349,7 +2340,6 @@ information contained within an event with the Event Receiver before
 transmitting the event. The mechanisms by which such validation is performed
 are outside the scope of this specification.
 
-
 ## Malicious Subject Removal {#management-sec-malicious-subject-removal}
 
 A malicious party may find it advantageous to remove a particular subject from a
@@ -2364,7 +2354,6 @@ amount of time after that subject has been removed from the stream. Event
 Receivers MUST tolerate receiving events for subjects that have been removed
 from the stream, and MUST NOT report these events as errors to the Event
 Transmitter.
-
 
 # Privacy Considerations {#privacy-considerations}
 
@@ -2435,7 +2424,6 @@ Change Controller
 
 > OpenID - Shared Signals Working Group
 
-
 --- back
 
 # Acknowledgements
@@ -2451,7 +2439,6 @@ Copyright (c) 2024 The OpenID Foundation.
 The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer, or other interested party a non-exclusive, royalty free, worldwide copyright license to reproduce, prepare derivative works from, distribute, perform and display, this Implementers Draft or Final Specification solely for the purposes of (i) developing specifications, and (ii) implementing Implementers Drafts and Final Specifications based on such documents, provided that attribution be made to the OIDF as the source of the material, but that such attribution does not indicate an endorsement by the OIDF.
 
 The technology described in this specification was made available from contributions from various sources, including members of the OpenID Foundation and others. Although the OpenID Foundation has taken steps to help ensure that the technology is available for distribution, it takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this specification or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any independent effort to identify any such rights. The OpenID Foundation and the contributors to this specification make no (and hereby expressly disclaim any) warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to this specification, and the entire risk as to implementing this specification is assumed by the implementer. The OpenID Intellectual Property Rights policy requires contributors to offer a patent promise not to assert certain patent claims against other contributors and against implementers. The OpenID Foundation invites any interested party to bring to its attention any copyrights, patents, patent applications, or other proprietary rights that may cover technology that may be required to practice this specification.
-
 
 # Document History
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -134,7 +134,7 @@ normative:
       name: Atul Tulshibagwale
     date: June 2024
     target: https://openid.net/specs/openid-caep-1_0.html
-    title: OpenID Continuous Access Evaluation Profile 1.0 - draft 03
+    title: OpenID Continuous Access Evaluation Profile 1.0
   RISC:
     author:
     -
@@ -157,7 +157,7 @@ normative:
       name: Atul Tulshibagwale
     date: April 2022
     target: https://openid.net/specs/openid-risc-profile-specification-1_0.html
-    title: OpenID RISC Profile Specification 1.0 - draft 02
+    title: OpenID RISC Profile Specification 1.0
   NAMINGCONVENTION:
     author:
     - name: OpenID Foundation

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -164,20 +164,12 @@ normative:
     target: https://openid.net/wg/resources/naming-and-contents-of-specifications/
     title: OpenID Naming and Content of Specifications
 
-informative:
-  USECASES:
-    author:
-    - ins: M. Scurtescu
-      name: Marius Scurtescu
-    date: June 2017
-    target: https://tools.ietf.org/html/draft-scurtescu-secevent-risc-use-cases-00
-    title: Security Events RISC Use Cases
-
 --- abstract
 
 This Shared Signals Framework (SSF) enables sharing of signals and events
-between cooperating peers. It enables multiple applications such as Risk Incident
-Sharing and Coordination (RISC) and the Continuous Access Evaluation Profile ({{CAEP}})
+between cooperating peers. It enables multiple applications such as Risk
+Incident Sharing and Coordination (RISC) and the Continuous Access Evaluation
+Profile ({{CAEP}})
 
 This specification defines:
 
@@ -189,7 +181,8 @@ This specification defines:
 * Transmitter Configuration Metadata and its discovery method for Receivers
 * A management API for Event Streams
 
-This specification also directly profiles several IETF Security Events specifications:
+This specification also directly profiles several IETF Security Events
+specifications:
 
 * Security Event Token (SET) {{RFC8417}}
 * Subject Identifiers for Security Event Tokens {{RFC9493}}
@@ -901,7 +894,8 @@ The following is a non-normative example of the `spec_urn`
         "spec_urn": "urn:ietf:rfc:6749"
    }
 ~~~
-{: #figspecurn title="Example: `spec_urn` specifying the OAuth protocol for authorization"}
+{: #figspecurn title="Example: `spec_urn` specifying the OAuth protocol for
+authorization"}
 
 In this case, the Receiver may obtain an access token using the Client
 Credentials Grant {{CLIENTCRED}}, or any other method suitable for the Receiver
@@ -1408,7 +1402,8 @@ GET /ssf/stream HTTP/1.1
 Host: transmitter.example.com
 Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 ~~~
-{: title="Example: Read Stream Configuration Request" #figreadconfigreqnostreamid}
+{: title="Example: Read Stream Configuration
+Request" #figreadconfigreqnostreamid}
 
 The following is a non-normative example response to a request with no
 "stream_id":
@@ -1474,7 +1469,8 @@ Cache-Control: no-store
   }
 ]
 ~~~
-{: title="Example: Read Stream Configuration Response" #figreadconfigrespnostreamidmanystreams}
+{: title="Example: Read Stream Configuration
+ Response" #figreadconfigrespnostreamidmanystreams}
 
 The following is a non-normative example response to a request with no
 "stream_id" when there is only one Event Stream configured:
@@ -1513,7 +1509,8 @@ Cache-Control: no-store
   }
 ]
 ~~~
-{: title="Example: Read Stream Configuration Response" #figreadconfigrespnostreamidonestream}
+{: title="Example: Read Stream Configuration
+ Response" #figreadconfigrespnostreamidonestream}
 
 The following is a non-normative example response to a request with no
 "stream_id" when there are no Event Streams configured:
@@ -1525,7 +1522,8 @@ Cache-Control: no-store
 
 []
 ~~~
-{: title="Example: Read Stream Configuration Response" #figreadconfigrespnostreamidnostreams}
+{: title="Example: Read Stream Configuration
+ Response" #figreadconfigrespnostreamidnostreams}
 
 Errors are signaled with HTTP status codes as follows:
 
@@ -1634,8 +1632,8 @@ HTTP PUT request to the Configuration Endpoint. The PUT body contains a JSON
 {{RFC7159}} representation of the new configuration. On receiving a valid
 request, the Event Transmitter responds with a "200 OK" response containing a
 JSON {{RFC7159}} representation of the updated stream configuration in the body.
-The Receiver MUST check the response and confirm that the `iss` value matches the
-Issuer from which it received the Transmitter Configuration data.
+The Receiver MUST check the response and confirm that the `iss` value matches
+the Issuer from which it received the Transmitter Configuration data.
 
 The stream_id and the full set of Receiver-Supplied properties MUST be present
 in the PUT body, not only those specifically intended to be changed.
@@ -1899,7 +1897,8 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
   "status": "paused"
 }
 ~~~
-{: title="Example: Update Stream Status Request Without Optional Fields" #figupdatestatusreq}
+{: title="Example: Update Stream Status Request Without Optional
+ Fields" #figupdatestatusreq}
 
 The following is a non-normative example of an Update Stream Status request with
 an optional reason:
@@ -1915,7 +1914,8 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
   "reason": "Disabled by administrator action."
 }
 ~~~
-{: title="Example: Update Stream Status Request With Optional Reason" #figupdatestatuswithreasonreq}
+{: title="Example: Update Stream Status Request With Optional
+Reason" #figupdatestatuswithreasonreq}
 
 The following is a non-normative example response:
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -2,7 +2,7 @@
 title: OpenID Shared Signals Framework Specification 1.0 - draft 22
 abbrev: SharedSignals
 docname: openid-sharedsignals-framework-1_0
-date: 2025-05-21
+date: 2025-05-22
 
 ipr: none
 cat: std

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -2,7 +2,7 @@
 title: OpenID Shared Signals Framework Specification 1.0 - draft 22
 abbrev: SharedSignals
 docname: openid-sharedsignals-framework-1_0
-date: 2025-05-15
+date: 2025-05-21
 
 ipr: none
 cat: std
@@ -21,31 +21,26 @@ author:
         name: Atul Tulshibagwale
         org: SGNL
         email: atul@sgnl.ai
-
       -
         ins: T. Cappalli
         name: Tim Cappalli
         org: Microsoft
         email: tim.cappalli@microsoft.com
-
       -
         ins: M. Scurtescu
         name: Marius Scurtescu
         org: Coinbase
         email: marius.scurtescu@coinbase.com
-
       -
         ins: A. Backman
         name: Annabelle Backman
         org: Amazon
         email: richanna@amazon.com
-
       -
         ins: J. Bradley
         name: John Bradley
         org: Yubico
         email: secevemt@ve7jtb.com
-
       -
         ins: S. Miel
         name: Shayne Miel
@@ -60,31 +55,26 @@ contributor:
         email: steve.venema@forgerock.com
         contribution: |
           Steve defined the format field of Complex Subjects
-
       -
         ins: A. Deshpande
         name: Apoorva Deshpande
         org: Okta
         email: apoorva.deshpande@okta.com
-
       -
         ins: S. O'Dell
         name: Sean O'Dell
         org: The Walt Disney Company
         email: sean.odentity@disney.com
-
       -
         ins: J. Schreiber
         name: Jen Schreiber
         org: Workday
         email: jennifer.winer@workday.com
-
       -
         ins: T. Raibhandare
         name: Tushar Raibhandare
         org: Google
         email: traib@google.com
-
       -
         ins: Y. Sarig
         name: Yair Sarig
@@ -238,18 +228,23 @@ Subject Principals are identified by Subject Members defined below.
 # Subject Members in SSF Events {#subject-ids}
 
 ## Subject Members {#subject-members}
+
 A Subject Member of an SSF event describes a subject of the event. A top-level claim named `sub_id` MUST be used to describe the primary subject of the event.
 
 ### Existing CAEP and RISC Events
+
 Event types already defined in the CAEP ({{CAEP}}) and RISC ({{RISC}}) specifications MAY use a `subject` field within the `events` claim of the SSF event to describe the primary Subject Principal of the event. SSF Transmitters MUST include the top-level `sub_id` claim even for these existing event types.
 
 ### New Event Types
+
 New event types MUST use the top-level `sub_id` claim and MUST NOT use the `subject` field in the `events` claim to describe the primary Subject Principal.
 
 ### Additional Subject Members
+
 Specific event types MAY define additional Subject Members if required to describe additional subjects of that event type (e.g. a Transferee). These additional subject fields MAY have any field name.
 
 ### Subject Member Values
+
 Each Subject Member MUST refer to exactly one Subject Principal. The value of a Subject Member MAY be a "simple subject" or a "complex subject".
 
 ## Simple Subject Members {#simple-subjects}
@@ -448,10 +443,12 @@ that it is unable to process.
 # Events {#events}
 
 ## Security Event Token Profile {#set-profle}
+
 The Shared Signals Framework profiles the Security Event Token (SET)
 {{RFC8417}} specification by defining certain properties of SETs as described in this section.
 
 ### Explicit Typing of SETs {#explicit-typing}
+
 SSF events MUST use explicit typing as defined in Section 2.3 of {{RFC8417}}.
 
 ~~~ json
@@ -468,10 +465,12 @@ validators may not be using the "typ" header parameter, requiring it for SSF
 SETs guarantees a distinct value for future validators.
 
 ### SSF Event Subject {#event-subjects}
+
 The primary Subject Member of SSF events is described in the "Subject Members" section ({{subject-ids}}). The JWT "sub" claim MUST NOT be present in any SET containing
 an SSF event.
 
 ### Distinguishing SETs from other Kinds of JWTs
+
 Of particular concern is the possibility that SETs are confused for other kinds
 of JWTs. Section 4 of {{RFC8417}} has several sub-sections
 on this subject. The Shared Signals Framework requires further restrictions:
@@ -481,21 +480,25 @@ on this subject. The Shared Signals Framework requires further restrictions:
 * The "exp" claim MUST NOT be present, as described in {{exp-claim}}.
 
 ### Signature Key Resolution {#signature-key-resolution}
+
 The signature key can be obtained through "jwks_uri", see {{discovery}}.
 
 ### The "iss" Claim {#iss-claim}
+
 The "iss" claim MUST match the "iss" value in the Stream Configuration data for the stream
 that the event is sent on. Receivers MUST validate that this claim matches the "iss"
 in the Stream Configuration data, as well as the Issuer from which the Receiver requested
 the Transmitter Configuration data.
 
 ### The "exp" Claim {#exp-claim}
+
 The "exp" claim MUST NOT be used in SETs.
 
 The purpose is defense in depth against confusion with other JWTs, as described
 in Sections 4.5 and 4.6 of {{RFC8417}}.
 
 ### The "aud" Claim {#aud-claim}
+
 The "aud" claim can be a single string or an array of strings. Values that
 uniquely identify the Receiver to the Transmitter MAY be used, if the two parties
 have agreement on the format.
@@ -533,18 +536,22 @@ multiple Receivers would lead to unintended data disclosure.
 {: title="Example: SET with array 'aud' claim" #figarrayaud}
 
 ### The "txn" claim {#txn-claim}
+
 Transmitters SHOULD set the "txn" claim value in Security Event Tokens (SETs). If the value is present, it MUST be unique to the underlying event that caused the Transmitter to generate the Security Event Token (SET). The Transmitter, however, may use the same value in the "txn" claim across different Security Events Tokens (SETs), such as session revoked and credential change, to indicate that the SETs originated from the same underlying cause or reason.
 
 ## Event Properties {#event-properties}
 
 ### The "events" claim {#events-claim}
+
 The "events" claim SHOULD contain only one event. Multiple event type URIs are
 permitted only if they are alternative URIs defining the exact same event type. The type of the event is specified by the key in the value of the `events` claim. The value of this field is the event object.
 
 ### Event type specific fields
+
 The event object inside the `events` claim MAY have one or more fields that are uniquely determined by the type of the event.
 
 ### Additional fields
+
 Transmitters MAY include additional fields in SSF events. These fields MAY exist anywhere in the SET, including the event object inside the "events" claim. Receivers MUST ignore any fields they do not understand from the SSF events they receive.
 
 # Example SETs that conform to the Shared Signals Framework {#events-examples}
@@ -695,13 +702,16 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
 {: #subject-custom-type-ex title="Example: SET Containing an SSF Event with a Proprietary Subject Identifier Format"}
 
 # Event Delivery {#event-delivery}
+
 This section describes the supported methods of delivering SSF Events. It provides SSF profiling specifications for the {{RFC8935}} and {{RFC8936}} specs.
 
 ## Stream Configuration Metadata {#delivery-meta}
+
 Each delivery method is identified by a URI, specified below by the "method"
 metadata.
 
 ### Push Delivery using HTTP
+
 This section provides SSF profiling specifications for the {{RFC8935}} spec.
 
 method
@@ -720,6 +730,7 @@ authorization_header
 > If the endpoint_url requires authorization, the receiver SHOULD provide this authorization header in the stream creation/updation. If present, the Transmitter MUST provide this value with every HTTP request to the `endpoint_url`.
 
 ### Poll Delivery using HTTP
+
 This section provides SSF profiling specifications for the {{RFC8936}} spec.
 
 method
@@ -824,6 +835,7 @@ TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
 {{RFC8414}}. This would allow other specs to add to the metadata.
 
 ### Authorization scheme {#authorization-scheme}
+
 SSF is an HTTP based signals sharing framework and is agnostic to the authentication and authorization schemes used to secure stream configuration APIs. It does not provide any SSF-specific authentication and authorization schemes but relies on the cooperating parties' mutual security considerations.
 
 The `authorization_schemes` key of Transmitter Configuration Metadata provides authorization information related to the Transmitter's stream management APIs. These authorization schemes SHOULD also be used to protect any polling endpoint (used for Poll-Based SET delivery [RFC8936]) hosted by the Transmitter.
@@ -893,6 +905,7 @@ is for supporting multiple issuers per host; unlike its use in {{RFC8615}}, it
 does not provide general information about the host.
 
 ### Backward Compatibility for RISC Transmitters
+
 Existing RISC Transmitters MAY continue to use the path component
 "/risc-configuration" instead of the path component "/ssf-configuration" in the
 path for the Transmitter Configuration Metadata. New services supporting the
@@ -908,6 +921,7 @@ Host: risc-tr.example.com
 {: #figolddiscoveryrequest title="Example: Transmitter Configuration Request for RISC Transmitters"}
 
 ### Transmitter Configuration Response
+
 The response is a set of Claims about the Transmitter's configuration, including
 all necessary endpoints and public key location information. A successful
 response MUST use the 200 OK HTTP status code and return a JSON object using the
@@ -960,6 +974,7 @@ Content-Type: application/json
 {: #figdiscoveryresponse title="Example: Transmitter Configuration Response"}
 
 ### Transmitter Configuration Validation
+
 If any of the validation procedures defined in this specification fail, any
 operations requiring the information that failed to correctly validate MUST be
 aborted and the information that failed to validate MUST NOT be used.
@@ -970,6 +985,7 @@ identical to the "iss" Claim value in Security Event Tokens issued from this
 Transmitter.
 
 # Management API for SET Event Streams {#management}
+
 An Event Stream is an abstraction for how events are communicated from a
 Transmitter to a Receiver. The Event Stream's configuration, which is jointly
 managed by the Transmitter and Receiver, holds information about
@@ -1019,6 +1035,7 @@ RECOMMENDED that they implement it, especially the endpoints for querying the
 Stream Status and for triggering Verification.
 
 ## Event Stream Management {#management-api}
+
 Event Receivers manage how they receive events and the subjects about which
 they want to receive events over an Event Stream by making HTTP requests to
 endpoints in the Event Stream Management API.
@@ -1060,6 +1077,7 @@ e.g. from authentication credentials. The definition of such mechanisms is
 outside the scope of this specification.
 
 ### Stream Configuration {#stream-config}
+
 An Event Stream’s configuration is a collection of data, provided by both the
 Transmitter and the Receiver, that describes the information being sent over
 the Event Stream. It is represented as a JSON {{RFC7159}} object with the
@@ -1154,6 +1172,7 @@ the stream configuration.
 
 
 #### Creating a Stream {#creating-a-stream}
+
 In order to communicate events from a Transmitter to a Receiver, a Receiver
 MUST first create an Event Stream. An Event Receiver creates a stream by making
 an HTTP POST request to the Configuration Endpoint. On receiving a valid request
@@ -1261,6 +1280,7 @@ A Transmitter and Receiver MAY agree upon the audience value out of band.
 Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure that it matches what it expects.
 
 #### Reading a Stream’s Configuration {#reading-a-streams-configuration}
+
 An Event Receiver gets the current configuration of a stream by making an HTTP
 GET request to the Configuration Endpoint. On receiving a valid request, the
 Event Transmitter responds with a "200 OK" response containing a [JSON][RFC7159]
@@ -1458,6 +1478,7 @@ Errors are signaled with HTTP status codes as follows:
 {: title="Read Stream Configuration Errors" #tabreadconfig}
 
 #### Updating a Stream’s Configuration {#updating-a-streams-configuration}
+
 An Event Receiver updates the current configuration of a stream by making an
 HTTP PATCH request to the Configuration Endpoint. The PATCH body contains a
 [JSON][RFC7159] representation of the stream configuration properties to change. On
@@ -1547,6 +1568,7 @@ Pending conditions or errors are signaled with HTTP status codes as follows:
 {: title="Update Stream Configuration Errors" #tabupdateconfig}
 
 #### Replacing a Stream’s Configuration {#replacing-a-streams-configuration}
+
 An Event Receiver replaces the current configuration of a stream by making an
 HTTP PUT request to the Configuration Endpoint. The PUT body contains a JSON
 {{RFC7159}} representation of the new configuration. On receiving a valid
@@ -1640,6 +1662,7 @@ Pending conditions or errors are signaled with HTTP status codes as follows:
 {: title="Replace Stream Configuration Errors" #tabreplaceconfig}
 
 #### Deleting a Stream {#deleting-a-stream}
+
 An Event Receiver deletes a stream by making an HTTP DELETE request to the
 Configuration Endpoint. On receiving a request, the Event Transmitter responds
 with an empty "204 No Content" response if the configuration was successfully removed.
@@ -1674,6 +1697,7 @@ Errors are signaled with HTTP status codes as follows:
 {: title="Delete Stream Errors" #tabdeletestream"}
 
 ### Stream Status {#status}
+
 Event Streams are managed independently. A Receiver MAY request that events from a
 stream be interrupted by Updating the Stream Status ({{updating-a-streams-status}}).
 If a Transmitter decides to enable, pause or disable updates from a stream
@@ -1681,6 +1705,7 @@ independently of an update request from a Receiver, it MUST send a Stream Update
 ({{stream-updated-event}}) to the Receiver.
 
 #### Reading a Stream’s Status {#reading-a-streams-status}
+
 An Event Receiver checks the current status of an Event Stream by making an HTTP
 GET request to the stream’s Status Endpoint.
 
@@ -1776,6 +1801,7 @@ Examples:
    Transmitter MUST respond with a 404 error status.
 
 #### Updating a Stream's Status {#updating-a-streams-status}
+
 An Event Receiver updates the current status of a stream by making an HTTP POST
 request to the Status Endpoint. The POST body contains a [JSON][RFC7159] object
 with the following fields:
@@ -1861,6 +1887,7 @@ Examples:
    respond with a 202 status code.
 
 ### Subjects {#subjects}
+
 An Event Receiver can indicate to an Event Transmitter whether or not the
 Receiver wants to receive events about a particular subject by “adding” or
 “removing” that subject to the Event Stream, respectively.
@@ -1976,6 +2003,7 @@ event over the Receiver's stream.
 ~~~
 
 #### Adding a Subject to a Stream {#adding-a-subject-to-a-stream}
+
 To add a subject to an Event Stream, the Event Receiver makes an HTTP POST
 request to the Add Subject Endpoint, containing in the body a JSON object the
 following claims:
@@ -2042,6 +2070,7 @@ Errors are signaled with HTTP status codes as follows:
 {: title="Add Subject Errors" #tabadderr}
 
 #### Removing a Subject {#removing-a-subject}
+
 To remove a subject from an Event Stream, the Event Receiver makes an HTTP POST
 request to the Remove Subject Endpoint, containing in the body a JSON object
 with the following claims:
@@ -2096,6 +2125,7 @@ Errors are signaled with HTTP status codes as follows:
 {: title="Remove Subject Errors" #tabremoveerr}
 
 ### Verification {#verification}
+
 In some cases, the frequency of event transmission on an Event Stream will be
 very low, making it difficult for an Event Receiver to tell the difference
 between expected behavior and event transmission failure due to a misconfigured
@@ -2112,6 +2142,7 @@ A Transmitter MAY respond to Verification Event requests even if the event is no
 
 
 #### Verification Event {#verification-event}
+
 The Verification Event is an SSF event with the event type: "https://schemas.openid.net/secevent/ssf/event-type/verification". The event contains the following attribute:
 
 state
@@ -2139,6 +2170,7 @@ fails to successfully verify based on the acknowledgement or lack of
 acknowledgement by the Event Receiver.
 
 #### Triggering a Verification Event. {#triggering-a-verification-event}
+
 To request that a Verification Event be sent over an Event Stream, the Event
 Receiver makes an HTTP POST request to the Verification Endpoint, with a [JSON]
 [RFC7159] object containing the parameters of the verification request, if any.
@@ -2224,6 +2256,7 @@ Event Receiver as a result of the above request:
 {: title="Example: Verification SET" #figverifyset}
 
 ### Stream Updated Event {#stream-updated-event}
+
 A Transmitter MAY change the stream status
 without a request from a Receiver. The Transmitter sends an event of type
 "https://schemas.openid.net/secevent/ssf/event-type/stream-updated" to indicate
@@ -2284,6 +2317,7 @@ sub_id
 # Security Considerations {#management-sec}
 
 ## Subject Probing {#management-sec-subject-probing}
+
 It may be possible for an Event Transmitter to leak information about subjects
 through their responses to add subject requests. A "404" response may indicate
 to the Event Receiver that the subject does not exist, which may inadvertently
@@ -2298,6 +2332,7 @@ that they will receive events related to the subject.
 
 
 ## Information Harvesting {#management-sec-information-harvesting}
+
 SETs may contain personally identifiable information (PII) or other non-public
 information about the Event Transmitter, the subject (of an event in the SET),
 or the relationship between the two. It is important for Event Transmitters to
@@ -2316,6 +2351,7 @@ are outside the scope of this specification.
 
 
 ## Malicious Subject Removal {#management-sec-malicious-subject-removal}
+
 A malicious party may find it advantageous to remove a particular subject from a
 stream, in order to reduce the Event Receiver’s ability to detect malicious
 activity related to the subject, inconvenience the subject, or for other reasons.
@@ -2333,6 +2369,7 @@ Transmitter.
 # Privacy Considerations {#privacy-considerations}
 
 ## Subject Information Leakage {#sub-info-leakage}
+
 Event Transmitters and Receivers SHOULD take precautions to ensure that they do not
 leak information about subjects via Subject Identifiers, and choose appropriate
 Subject Identifier Types accordingly. Parties SHOULD NOT identify a subject
@@ -2344,6 +2381,7 @@ communicating with a given party in order to reduce the possibility of
 information leakage.
 
 ## Previously Consented Data {#previously-consented-data}
+
 If SSF events contain new values for attributes of Subject Principals that were
 previously exchanged between the Transmitter and Receiver, then there are no
 additional privacy considerations introduced by providing the updated values in
@@ -2351,10 +2389,12 @@ the SSF events, unless the attribute was exchanged under a one-time consent
 obtained from the user.
 
 ## New Data {#new-data}
+
 Data that was not previously exchanged between the Transmitter and the Receiver,
 or data whose consent to exchange has expired has the following considerations:
 
 ### Organizational Data {#organizational-data}
+
 If a user has previously agreed with a Transmitter that they allow the release of
 certain data to third-parties, then the Transmitter MAY send such data in SSF
 events without additional consent of the user. Such data MAY include
@@ -2362,12 +2402,14 @@ organizational data about the Subject Principal that was generated by the
 Transmitter.
 
 ### Consentable Data {#consentable-data}
+
 If a Transmitter intends to include data in SSF events that is not previously
 consented to be released by the user, then the Transmitter MUST obtain consent
 to release such data from the user in accordance with the Transmitter's privacy
 policy.
 
 # IANA Considerations {#iana}
+
 Subject Identifiers defined in this document will be added to the "Security
 Events Subject Identifier Types" registry. This registry is defined in the
 Subject Identifiers for Security Event Tokens {{RFC9493}} specification.

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -754,8 +754,8 @@ Transmitters have metadata describing their configuration:
 spec_version
 
 > OPTIONAL. A version identifying the implementer's draft or final specification implemented by the Transmitter. This includes the numerical portion of the spec version as described in the document {{NAMINGCONVENTION}}. If absent, the Transmitter is assumed to conform to "1_0-ID1" version of the specification.
-
->  The following is a non-normative example of a Transmitter that implements the final specification of the Shared Signals Framework 1_0.
+>
+> The following is a non-normative example of a Transmitter that implements the final specification of the Shared Signals Framework 1_0.
 
 ~~~ json
    {
@@ -819,19 +819,15 @@ default_subjects
 > OPTIONAL. A string indicating the default behavior of newly created streams. If present,
   the value MUST be either "ALL" or "NONE". If not provided, the Transmitter behavior in
   this regard is unspecified.
-
->  - "ALL" indicates that any subjects that are appropriate for the stream are added to
+>
+> * "ALL" indicates that any subjects that are appropriate for the stream are added to
     the stream by default. The Receiver MAY remove subjects from the stream via the
     `remove_subject_endpoint`, causing events for those subjects to _not_ be transmitted.
     The Receiver MAY re-add any subjects removed this way via the `add_subject_endpoint`.
-
->  - "NONE" indicates that no subjects are added by default. The Receiver MAY add subjects
+> * "NONE" indicates that no subjects are added by default. The Receiver MAY add subjects
     to the stream via the `add_subject_endpoint`, causing only events for those subjects
     to be transmitted. The Receiver MAY remove subjects added this way via the
     `remove_subject_endpoint`.
-
-TODO: consider adding a IANA Registry for metadata, similar to Section 7.1.1 of
-{{RFC8414}}. This would allow other specs to add to the metadata.
 
 ### Authorization scheme {#authorization-scheme}
 
@@ -1005,7 +1001,7 @@ This authorization MUST associate a Receiver with one or more stream IDs and "au
 such that only authorized Receivers are able to access or modify the details of the
 associated Event Streams.
 
-~~~
+~~~ascii
 +------------+                +------------+
 |            | Stream Config  |            |
 | Event      <----------------+ Event      |
@@ -1154,20 +1150,16 @@ inactivity_timeout
 >
 > The following constitutes eligible Receiver activity. If the Transmitter observes any of these activities from the Receiver, it MUST restart the inactivity timeout counter.
 >
-> >   For streams created with the PUSH {{RFC8935}} delivery method:
+> > For streams created with the PUSH {{RFC8935}} delivery method:
 > >
-> >   * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
-> > 
-> >   For streams created with the POLL {{RFC8936}} delivery method:
-> > 
-> >   * The Receiver polls the Transmitter for events in the stream.
-> >   * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
+> > * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
+> >
+> > For streams created with the POLL {{RFC8936}} delivery method:
+> >
+> > * The Receiver polls the Transmitter for events in the stream.
+> > * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
 >
 > If the Transmitter decides to pause or disable the stream, it MUST send a Stream Updated Event to the Receiver as described in {{status}}.
-
-TODO: consider adding a IANA Registry for stream configuration metadata, similar
-to Section 7.1.1 of {{RFC8414}}. This would allow other specs to add to
-the stream configuration.
 
 #### Creating a Stream {#creating-a-stream}
 
@@ -1175,7 +1167,7 @@ In order to communicate events from a Transmitter to a Receiver, a Receiver
 MUST first create an Event Stream. An Event Receiver creates a stream by making
 an HTTP POST request to the Configuration Endpoint. On receiving a valid request
 the Event Transmitter responds with a "201 Created" response containing a
-[JSON][RFC7159] representation of the stream’s configuration in the body. The Receiver
+JSON {{RFC7159}} representation of the stream’s configuration in the body. The Receiver
 MUST check the response and confirm that the `iss` value matches the Issuer from
 which it received the Transmitter Configuration data.
 
@@ -1279,7 +1271,7 @@ Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure 
 
 An Event Receiver gets the current configuration of a stream by making an HTTP
 GET request to the Configuration Endpoint. On receiving a valid request, the
-Event Transmitter responds with a "200 OK" response containing a [JSON][RFC7159]
+Event Transmitter responds with a "200 OK" response containing a JSON {{RFC7159}}
 representation of the stream’s configuration in the body.  The Receiver
 MUST check the response and confirm that the `iss` value matches the Issuer from
 which it received the Transmitter Configuration data.
@@ -1476,9 +1468,9 @@ Errors are signaled with HTTP status codes as follows:
 
 An Event Receiver updates the current configuration of a stream by making an
 HTTP PATCH request to the Configuration Endpoint. The PATCH body contains a
-[JSON][RFC7159] representation of the stream configuration properties to change. On
+JSON {{RFC7159}} representation of the stream configuration properties to change. On
 receiving a valid request, the Event Transmitter responds with a "200 OK"
-response containing a [JSON][RFC7159] representation of the entire updated stream
+response containing a JSON {{RFC7159}} representation of the entire updated stream
 configuration in the body. The Receiver MUST check the response and confirm that the
 `iss` value matches the Issuer from which it received the Transmitter Configuration data.
 
@@ -1710,7 +1702,7 @@ stream_id
 > REQUIRED. A string identifying the stream whose status is being queried.
 
 On receiving a valid request, the Event Transmitter responds with a 200 OK
-response containing a [JSON][RFC7159] object with the following attributes:
+response containing a JSON {{RFC7159}} object with the following attributes:
 
 stream_id
 
@@ -1797,7 +1789,7 @@ Examples:
 #### Updating a Stream's Status {#updating-a-streams-status}
 
 An Event Receiver updates the current status of a stream by making an HTTP POST
-request to the Status Endpoint. The POST body contains a [JSON][RFC7159] object
+request to the Status Endpoint. The POST body contains a JSON {{RFC7159}} object
 with the following fields:
 
 stream_id
@@ -1813,7 +1805,7 @@ reason
 > OPTIONAL. A short text description that explains the reason for the change.
 
 On receiving a valid request, the Event Transmitter responds with a "200 OK"
-response containing a [JSON][RFC7159] representation of the updated stream
+response containing a JSON {{RFC7159}} representation of the updated stream
 status in the body, using the same fields as described in the request.
 
 The following is a non-normative example request to update an Event Stream’s
@@ -1904,8 +1896,9 @@ The following is a non-normative example of subject matching for Complex Subject
 when a Receiver adds a subject that is less restrictive than the subject being sent
 by the Transmitter.
 
-~~~
 The Receiver has added the following subject to their stream:
+
+~~~json
 {
   "format": "complex",
   "tenant": {
@@ -1913,8 +1906,11 @@ The Receiver has added the following subject to their stream:
     "id": "example-a38h4792-uw2"
   }
 }
+~~~
 
 The Transmitter has an event to broadcast with the following subject:
+
+~~~json
 {
   "format": "complex",
   "tenant": {
@@ -1926,17 +1922,18 @@ The Transmitter has an event to broadcast with the following subject:
     "email": "jdoe@example.com"
   }
 }
+~~~
 
 According to the matching rules described above, the Transmitter SHOULD broadcast the
 event over the Receiver's stream.
-~~~
 
 The following is a non-normative example of subject matching for Complex Subjects
 when a Receiver adds a subject that is more restrictive than the subject being sent
 by the Transmitter.
 
-~~~
 The Receiver has added the following subject to their stream:
+
+~~~json
 {
   "format": "complex",
   "user": {
@@ -1948,24 +1945,28 @@ The Receiver has added the following subject to their stream:
     "ip-addresses": ["10.29.37.75"]
   }
 }
+~~~
 
 The Transmitter has an event to broadcast with the following subject:
+
+~~~json
 {
   "format": "complex",
   "user": {
-    "format": "email":
+    "format": "email",
     "email": "jdoe@example.com"
   }
 }
+~~~
 
 According to the matching rules described above, the Transmitter SHOULD broadcast the
 event over the Receiver's stream.
-~~~
 
 The following is a non-normative example of two Complex Subjects that do not match.
 
-~~~
 The Receiver has added the following subject to their stream:
+
+~~~json
 {
   "format": "complex",
   "user": {
@@ -1977,12 +1978,15 @@ The Receiver has added the following subject to their stream:
     "url": "did:example:123456"
   }
 }
+~~~
 
 The Transmitter has an event to broadcast with the following subject:
+
+~~~json
 {
   "format": "complex",
   "user": {
-    "format": "email":
+    "format": "email",
     "email": "jdoe@example.com"
   },
   "group": {
@@ -1990,10 +1994,10 @@ The Transmitter has an event to broadcast with the following subject:
     "url": "did:example:9999999"
   }
 }
+~~~
 
 According to the matching rules described above, the Transmitter SHOULD NOT broadcast the
 event over the Receiver's stream.
-~~~
 
 #### Adding a Subject to a Stream {#adding-a-subject-to-a-stream}
 
@@ -2147,7 +2151,7 @@ As with any SSF event, the Verification Event has a top-level `sub_id` claim:
 sub_id
 
 > REQUIRED. The value of the top-level `sub_id` claim in a Verification Event MUST always be set to have a simple value of type `opaque`. The `id` of the value MUST be the `stream_id` of the stream being verified.
-
+>
 > Note that the subject that identifies a stream itself is always implicitly
   added to the stream and MAY NOT be removed from the stream.
 
@@ -2280,10 +2284,10 @@ As with any SSF event, this event has a top-level `sub_id` claim:
 sub_id
 
 > REQUIRED. The top-level `sub_id` claim specifies the Stream Id for which the status has been updated. The value of the `sub_id` field MUST be of format `opaque`, and its `id` value MUST be the unique ID of the stream.
-
+>
 > Note that the subject that identifies a stream itself is always implicitly
   added to the stream and MAY NOT be removed from the stream.
-
+>
 > Below is a non-normative example of a Stream Updated event.
 
 ~~~ json
@@ -2443,71 +2447,73 @@ The technology described in this specification was made available from contribut
 # Document History
 
   [[ To be removed from the final specification ]]
-  -20
-    * Clarified that Transmitters may drop events if they aren't able to deliver them to the receiver.
-    * Added examples to demonstrate how "wildcard matching" works in SSF event complex subjects
-    * Added an `inactivity_timeout` field to the Transmitter metadata, after which transmitters may pause, disable or delete inactive streams.
-    * Clarified that Receivers should validate the `aud` value
-    * Clarified that Transmitters may include additional fields in SSF events, and how receivers should interpret them.
-    * Specified that the poll delivery endpoint should require authorization
-    * Clarified stream creation behavior for delivery method mismatch and poll delivery
-    * Clarified that StreamIDs have to be of the "unreserved characters" character set from RFC3986
-    * Clarified the authorization_header requirement for the receiver
-    * Rearranged the content for easier readability: Eliminated the "Profiles" section (previous section 10). Created new sections "Events" (new section 4), and "Event Delivery" (new Section 6). Incorporated text from the erstwhile "Profiles" section into other sections as appropriate. Fixed references and titles of examples.
-    * Added "IP Address" as a subject identifier format
-    * In Create Stream, specified that description may be included in the response, and that the `endpoint_url` is specified by the Transmitter in the `poll` delivery method
-    * Updated URLs of linked specs and other resources
-    * Fixed example to have correct format for "reason_admin" and "reason_user"
 
-  -03
+-20
 
-    * Removing transmitter supplied fields from stream config PUT and PATCH examples
-    * Add OPTIONAL/REQUIRED to the fields in the stream configuration
-    * Add stream_id to the response when getting stream status
-    * Update subject/sub_id in examples. Fix CAEP example
-    * Clarify language around sending Stream Updated events
-    * Add sentence suggesting that Issuer information should be validated by the Receiver
-    * Removed cause-time from RISC example
-    * Fix description of error code for invalid state
-    * Add SHOULD language about checking the issuer value
-    * Added language requiring authorization of stream management API
-    * Added description of `txn` claim
-    * Added a `default_subjects` field to Transmitter Configuration Metadata indicating expected subject behavior for new streams
-    * added txn claims to non-normative SET examples and generic txn callout under SET Profile section RFC8417
-    * Editorial: Standardize terms and casing, fix some typos
+* Clarified that Transmitters may drop events if they aren't able to deliver them to the receiver.
+* Added examples to demonstrate how "wildcard matching" works in SSF event complex subjects
+* Added an `inactivity_timeout` field to the Transmitter metadata, after which transmitters may pause, disable or delete inactive streams.
+* Clarified that Receivers should validate the `aud` value
+* Clarified that Transmitters may include additional fields in SSF events, and how receivers should interpret them.
+* Specified that the poll delivery endpoint should require authorization
+* Clarified stream creation behavior for delivery method mismatch and poll delivery
+* Clarified that StreamIDs have to be of the "unreserved characters" character set from RFC3986
+* Clarified the authorization_header requirement for the receiver
+* Rearranged the content for easier readability: Eliminated the "Profiles" section (previous section 10). Created new sections "Events" (new section 4), and "Event Delivery" (new Section 6). Incorporated text from the erstwhile "Profiles" section into other sections as appropriate. Fixed references and titles of examples.
+* Added "IP Address" as a subject identifier format
+* In Create Stream, specified that description may be included in the response, and that the `endpoint_url` is specified by the Transmitter in the `poll` delivery method
+* Updated URLs of linked specs and other resources
+* Fixed example to have correct format for "reason_admin" and "reason_user"
 
-  -02
+-03
 
-    * added spec version to metadata
-    * Added description as receiver supplied
-    * added language to make verification and updated events independent of events_supported
-    * added top-level sub_id claim. Modified existing language to reflect the use of the sub_id claim
-    * updated text to reflect sub_id as a top-level field in verification and stream updated events
-    * #46 add stream exists behavior
-    * update stream exists to 409
-    * Add 'format' to normative examples in CAEP
-    * Remove 'format' from stream config
-    * Remove subject from stream status (#88)
-    * Add reason to GET /status response
-    * Make reason look like an enum in the example to indicate how we expect it to be used
-    * Fixes #60 - are subjects required
-    * Added format field to complex subjects and updated examples (#71)
-    * Switch stray '204 OK' to read '204 No Content' (#73)
-    * Change 'jwt-id' to 'jwt_id' to match style of other subject formats (#63)
-    * resolving issue #45 added explanatory text to Stream Configuration (#68)
-    * #28 update delivery method references to URNs (#49)
-    * Changed jwks_uri from REQUIRED to OPTIONAL (#47)
-    * Sse to ssf (#43)
-    * updated SSE to Shared Signals in all files
-    * changed source format to md
-    * renamed files to be called sharedsignals instead of SSE. No change to the content (#41)
-    * Add stream_id to SSE Framework spec as per Issue 4: https://github.com/openid/sse/issues/4
-    * Update README with development instructions and fix error in Makefile
-    * Added note to PUSH/POLL section about uniqueness requirements for the URLs
-    * Add explanation about what an Event Stream is
-    * Change terms to Transmitter-Supplied and Receiver-Supplied
-    * Pragma is an obsolete HTTP header
-    * It's unnecessary to specify the character as UTF-8 in all examples (#10)
-    * Fix issue #18 by converting saml-assertion-id to saml_assertion_id to maintain consistent formatting with other subject identifiers (#1)
-    * updated backward compatibility language
-    * added section for Transmitter Configuration Metadata RISC compatibility
+* Removing transmitter supplied fields from stream config PUT and PATCH examples
+* Add OPTIONAL/REQUIRED to the fields in the stream configuration
+* Add stream_id to the response when getting stream status
+* Update subject/sub_id in examples. Fix CAEP example
+* Clarify language around sending Stream Updated events
+* Add sentence suggesting that Issuer information should be validated by the Receiver
+* Removed cause-time from RISC example
+* Fix description of error code for invalid state
+* Add SHOULD language about checking the issuer value
+* Added language requiring authorization of stream management API
+* Added description of `txn` claim
+* Added a `default_subjects` field to Transmitter Configuration Metadata indicating expected subject behavior for new streams
+* added txn claims to non-normative SET examples and generic txn callout under SET Profile section RFC8417
+* Editorial: Standardize terms and casing, fix some typos
+
+-02
+
+* added spec version to metadata
+* Added description as receiver supplied
+* added language to make verification and updated events independent of events_supported
+* added top-level sub_id claim. Modified existing language to reflect the use of the sub_id claim
+* updated text to reflect sub_id as a top-level field in verification and stream updated events
+* \#46 add stream exists behavior
+* update stream exists to 409
+* Add 'format' to normative examples in CAEP
+* Remove 'format' from stream config
+* Remove subject from stream status (#88)
+* Add reason to GET /status response
+* Make reason look like an enum in the example to indicate how we expect it to be used
+* Fixes \#60 - are subjects required
+* Added format field to complex subjects and updated examples (#71)
+* Switch stray '204 OK' to read '204 No Content' (#73)
+* Change 'jwt-id' to 'jwt_id' to match style of other subject formats (#63)
+* resolving issue \#45 added explanatory text to Stream Configuration (#68)
+* \#28 update delivery method references to URNs (#49)
+* Changed jwks_uri from REQUIRED to OPTIONAL (#47)
+* Sse to ssf (#43)
+* updated SSE to Shared Signals in all files
+* changed source format to md
+* renamed files to be called sharedsignals instead of SSE. No change to the content (#41)
+* Add stream_id to SSE Framework spec as per Issue 4: https://github.com/openid/sse/issues/4
+* Update README with development instructions and fix error in Makefile
+* Added note to PUSH/POLL section about uniqueness requirements for the URLs
+* Add explanation about what an Event Stream is
+* Change terms to Transmitter-Supplied and Receiver-Supplied
+* Pragma is an obsolete HTTP header
+* It's unnecessary to specify the character as UTF-8 in all examples (#10)
+* Fix issue \#18 by converting saml-assertion-id to saml_assertion_id to maintain consistent formatting with other subject identifiers (#1)
+* updated backward compatibility language
+* added section for Transmitter Configuration Metadata RISC compatibility

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -116,7 +116,6 @@ normative:
   RFC7517:
   RFC7519:
   RFC8174:
-  RFC8414:
   RFC8417:
   RFC8615:
   RFC8935:
@@ -177,8 +176,8 @@ informative:
 --- abstract
 
 This Shared Signals Framework (SSF) enables sharing of signals and events
-between cooperating peers. It enables multiple applications such as Risk Incident Sharing
-and Coordination (RISC) and the Continuous Access Evaluation Profile ({{CAEP}})
+between cooperating peers. It enables multiple applications such as Risk Incident
+Sharing and Coordination (RISC) and the Continuous Access Evaluation Profile ({{CAEP}})
 
 This specification defines:
 
@@ -229,30 +228,38 @@ Subject Principals are identified by Subject Members defined below.
 
 ## Subject Members {#subject-members}
 
-A Subject Member of an SSF event describes a subject of the event. A top-level claim named `sub_id` MUST be used to describe the primary subject of the event.
+A Subject Member of an SSF event describes a subject of the event. A top-level
+claimnamed `sub_id` MUST be used to describe the primary subject of the event.
 
 ### Existing CAEP and RISC Events
 
-Event types already defined in the CAEP ({{CAEP}}) and RISC ({{RISC}}) specifications MAY use a `subject` field within the `events` claim of the SSF event to describe the primary Subject Principal of the event. SSF Transmitters MUST include the top-level `sub_id` claim even for these existing event types.
+Event types already defined in the CAEP ({{CAEP}}) and RISC ({{RISC}})
+specifications MAY use a `subject` field within the `events` claim of the SSF
+event to describe the primary Subject Principal of the event. SSF Transmitters
+MUST include the top-level `sub_id` claim even for these existing event types.
 
 ### New Event Types
 
-New event types MUST use the top-level `sub_id` claim and MUST NOT use the `subject` field in the `events` claim to describe the primary Subject Principal.
+New event types MUST use the top-level `sub_id` claim and MUST NOT use the
+`subject` field in the `events` claim to describe the primary Subject Principal.
 
 ### Additional Subject Members
 
-Specific event types MAY define additional Subject Members if required to describe additional subjects of that event type (e.g. a Transferee). These additional subject fields MAY have any field name.
+Specific event types MAY define additional Subject Members if required to
+describe additional subjects of that event type (e.g. a Transferee). These
+additional subject fields MAY have any field name.
 
 ### Subject Member Values
 
-Each Subject Member MUST refer to exactly one Subject Principal. The value of a Subject Member MAY be a "simple subject" or a "complex subject".
+Each Subject Member MUST refer to exactly one Subject Principal. The value of a
+Subject Member MAY be a "simple subject" or a "complex subject".
 
 ## Simple Subject Members {#simple-subjects}
 
 A Simple Subject Member has a claim name and a value that is a "Subject
 Identifier" as defined in the Subject Identifiers for Security Event Tokens
-{{RFC9493}}. Below is a non-normative example of a Simple Subject Member in an SSF
-event.
+{{RFC9493}}. Below is a non-normative example of a Simple Subject Member in an
+SSF event.
 
 ~~~ json
 "sub_id": {
@@ -297,8 +304,8 @@ group
 
 > OPTIONAL. A Subject Identifier that identifies a group.
 
-Additional Subject Member names MAY be used in Complex Subjects. Each member name MAY
-appear at most once in the Complex Subject value.
+Additional Subject Member names MAY be used in Complex Subjects. Each member
+name MAY appear at most once in the Complex Subject value.
 
 Below is a non-normative example of a Complex Subject claim in an SSF event.
 
@@ -324,8 +331,8 @@ All members within a Complex Subject MUST represent attributes of the same
 Subject Principal. As a whole, the Complex Subject MUST refer to exactly one
 Subject Principal.
 
-For details about how to interpret unspecified claims in a Complex Subject as wildcards,
-please see the section on Subject Matching ({{subject-matching}}).
+For details about how to interpret unspecified claims in a Complex Subject as
+wildcards, please see the section on Subject Matching ({{subject-matching}}).
 
 ## Subject Identifiers in SSF Events {#subject-ids-in-ssf}
 
@@ -394,8 +401,8 @@ assertion_id
 The "SAML Assertion ID" Subject Identifier Format is identified by the name
 "saml_assertion_id".
 
-Below is a non-normative example of Subject Identifier for the "saml_assertion_id"
-Subject Identifier Format.
+Below is a non-normative example of Subject Identifier for the
+"saml_assertion_id" Subject Identifier Format.
 
 ~~~ json
 {
@@ -405,16 +412,20 @@ Subject Identifier Format.
 }
 
 ~~~
-{: #sub-id-samlassertionid title="Example: 'saml_assertion_id' Subject Identifier"}
+{: #sub-id-samlassertionid title="Example: 'saml_assertion_id' Subject
+Identifier"}
 
 ### IP Addresses Subject Identifier Format {#sub-id-ips}
 
-The "IP addresses" Subject Identifier Format specifies an array of IP addresses observed by the Transmitter.
-Subject Identifiers of this format MUST contain the following members:
+The "IP addresses" Subject Identifier Format specifies an array of IP addresses
+observed by the Transmitter. Subject Identifiers of this format MUST contain the
+following members:
 
 ip-addresses
 
-> REQUIRED. The array of IP addresses of the subject as observed by the Transmitter. The value MUST be in the format of an array of strings, each one of which represents the {{RFC4001}} string representation of an IP address.
+> REQUIRED. The array of IP addresses of the subject as observed by the
+Transmitter. The value MUST be in the format of an array of strings, each one of
+which represents the {{RFC4001}} string representation of an IP address.
 
 The "IP addresses" Subject Identifier Format is identified by the name
 "ip-addresses".
@@ -434,17 +445,18 @@ Subject Identifier Format.
 ## Receiver Subject Processing {#receiver-subject-processing}
 
 A SSF Receiver MUST make a best effort to process all members from a Subject in
-an SSF event. The Transmitter Configuration Metadata ({{discovery-meta}}) defined
-below MAY define certain members within a Complex Subject to be Critical. A SSF
-Receiver MUST discard any event that contains a Subject with a Critical member
-that it is unable to process.
+an SSF event. The Transmitter Configuration Metadata ({{discovery-meta}})
+defined below MAY define certain members within a Complex Subject to be
+Critical. A SSF Receiver MUST discard any event that contains a Subject with a
+Critical member that it is unable to process.
 
 # Events {#events}
 
 ## Security Event Token Profile {#set-profle}
 
 The Shared Signals Framework profiles the Security Event Token (SET)
-{{RFC8417}} specification by defining certain properties of SETs as described in this section.
+{{RFC8417}} specification by defining certain properties of SETs as described in
+this section.
 
 ### Explicit Typing of SETs {#explicit-typing}
 
@@ -465,8 +477,9 @@ SETs guarantees a distinct value for future validators.
 
 ### SSF Event Subject {#event-subjects}
 
-The primary Subject Member of SSF events is described in the "Subject Members" section ({{subject-ids}}). The JWT "sub" claim MUST NOT be present in any SET containing
-an SSF event.
+The primary Subject Member of SSF events is described in the "Subject Members"
+section ({{subject-ids}}). The JWT "sub" claim MUST NOT be present in any SET
+containing an SSF event.
 
 ### Distinguishing SETs from other Kinds of JWTs
 
@@ -484,10 +497,10 @@ The signature key can be obtained through "jwks_uri", see {{discovery}}.
 
 ### The "iss" Claim {#iss-claim}
 
-The "iss" claim MUST match the "iss" value in the Stream Configuration data for the stream
-that the event is sent on. Receivers MUST validate that this claim matches the "iss"
-in the Stream Configuration data, as well as the Issuer from which the Receiver requested
-the Transmitter Configuration data.
+The "iss" claim MUST match the "iss" value in the Stream Configuration data for
+the stream that the event is sent on. Receivers MUST validate that this claim
+matches the "iss" in the Stream Configuration data, as well as the Issuer from
+which the Receiver requested the Transmitter Configuration data.
 
 ### The "exp" Claim {#exp-claim}
 
@@ -499,8 +512,8 @@ in Sections 4.5 and 4.6 of {{RFC8417}}.
 ### The "aud" Claim {#aud-claim}
 
 The "aud" claim can be a single string or an array of strings. Values that
-uniquely identify the Receiver to the Transmitter MAY be used, if the two parties
-have agreement on the format.
+uniquely identify the Receiver to the Transmitter MAY be used, if the two
+parties have agreement on the format.
 
 More than one value can be present if the corresponding Receivers are known to
 the Transmitter to be the same entity, for example a web client and a mobile
@@ -536,26 +549,38 @@ multiple Receivers would lead to unintended data disclosure.
 
 ### The "txn" claim {#txn-claim}
 
-Transmitters SHOULD set the "txn" claim value in Security Event Tokens (SETs). If the value is present, it MUST be unique to the underlying event that caused the Transmitter to generate the Security Event Token (SET). The Transmitter, however, may use the same value in the "txn" claim across different Security Events Tokens (SETs), such as session revoked and credential change, to indicate that the SETs originated from the same underlying cause or reason.
+Transmitters SHOULD set the "txn" claim value in Security Event Tokens (SETs).
+If the value is present, it MUST be unique to the underlying event that caused
+the Transmitter to generate the Security Event Token (SET). The Transmitter,
+however, may use the same value in the "txn" claim across different Security
+Events Tokens (SETs), such as session revoked and credential change, to indicate
+that the SETs originated from the same underlying cause or reason.
 
 ## Event Properties {#event-properties}
 
 ### The "events" claim {#events-claim}
 
 The "events" claim SHOULD contain only one event. Multiple event type URIs are
-permitted only if they are alternative URIs defining the exact same event type. The type of the event is specified by the key in the value of the `events` claim. The value of this field is the event object.
+permitted only if they are alternative URIs defining the exact same event type.
+The type of the event is specified by the key in the value of the `events`
+claim. The value of this field is the event object.
 
 ### Event type specific fields
 
-The event object inside the `events` claim MAY have one or more fields that are uniquely determined by the type of the event.
+The event object inside the `events` claim MAY have one or more fields that are
+uniquely determined by the type of the event.
 
 ### Additional fields
 
-Transmitters MAY include additional fields in SSF events. These fields MAY exist anywhere in the SET, including the event object inside the "events" claim. Receivers MUST ignore any fields they do not understand from the SSF events they receive.
+Transmitters MAY include additional fields in SSF events. These fields MAY exist
+anywhere in the SET, including the event object inside the "events" claim.
+Receivers MUST ignore any fields they do not understand from the SSF events they
+receive.
 
 # Example SETs that conform to the Shared Signals Framework {#events-examples}
 
-The following are hypothetical examples of SETs that conform to the Shared Signals Framework.
+The following are hypothetical examples of SETs that conform to the Shared
+Signals Framework.
 
 ~~~ json
 {
@@ -573,7 +598,8 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #subject-ids-ex-simple title="Example: SET Containing an SSF Event with a Simple Subject Member"}
+{: #subject-ids-ex-simple title="Example: SET Containing an SSF Event with a
+Simple Subject Member"}
 
 ~~~ json
 {
@@ -593,7 +619,8 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #risc-event-subject-example title="Example: SET Containing a RISC Event with a Phone Number Subject"}
+{: #risc-event-subject-example title="Example: SET Containing a RISC Event with
+a Phone Number Subject"}
 
 ~~~ json
 {
@@ -615,7 +642,8 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #caep-event-properties-example title="Example: SET Containing a CAEP Event with Properties"}
+{: #caep-event-properties-example title="Example: SET Containing a CAEP Event
+with Properties"}
 
 ~~~ json
 {
@@ -652,7 +680,8 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #subject-ids-ex-complex title="Example: SET Containing an SSF Event with a Complex Subject Member"}
+{: #subject-ids-ex-complex title="Example: SET Containing an SSF Event with a
+Complex Subject Member"}
 
 ~~~ json
 {
@@ -675,7 +704,8 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #subject-properties-ex title="Example: SET Containing an SSF Event with a Simple Subject and a Property Member"}
+{: #subject-properties-ex title="Example: SET Containing an SSF Event with a
+Simple Subject and a Property Member"}
 
 ~~~ json
 {
@@ -698,11 +728,13 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
   }
 }
 ~~~
-{: #subject-custom-type-ex title="Example: SET Containing an SSF Event with a Proprietary Subject Identifier Format"}
+{: #subject-custom-type-ex title="Example: SET Containing an SSF Event with a
+Proprietary Subject Identifier Format"}
 
 # Event Delivery {#event-delivery}
 
-This section describes the supported methods of delivering SSF Events. It provides SSF profiling specifications for the {{RFC8935}} and {{RFC8936}} specs.
+This section describes the supported methods of delivering SSF Events. It
+provides SSF profiling specifications for the {{RFC8935}} and {{RFC8936}} specs.
 
 ## Stream Configuration Metadata {#delivery-meta}
 
@@ -726,7 +758,10 @@ endpoint_url
 
 authorization_header
 
-> If the endpoint_url requires authorization, the receiver SHOULD provide this authorization header in the stream creation/updation. If present, the Transmitter MUST provide this value with every HTTP request to the `endpoint_url`.
+> If the endpoint_url requires authorization, the receiver SHOULD provide this
+authorization header in the stream creation/updation. If present, the
+Transmitter MUST provide this value with every HTTP request to the
+`endpoint_url`.
 
 ### Poll Delivery using HTTP
 
@@ -753,16 +788,21 @@ Transmitters have metadata describing their configuration:
 
 spec_version
 
-> OPTIONAL. A version identifying the implementer's draft or final specification implemented by the Transmitter. This includes the numerical portion of the spec version as described in the document {{NAMINGCONVENTION}}. If absent, the Transmitter is assumed to conform to "1_0-ID1" version of the specification.
+> OPTIONAL. A version identifying the implementer's draft or final specification
+implemented by the Transmitter. This includes the numerical portion of the spec
+version as described in the document {{NAMINGCONVENTION}}. If absent, the
+Transmitter is assumed to conform to "1_0-ID1" version of the specification.
 >
-> The following is a non-normative example of a Transmitter that implements the final specification of the Shared Signals Framework 1_0.
+> The following is a non-normative example of a Transmitter that implements the
+> final specification of the Shared Signals Framework 1_0.
 
 ~~~ json
    {
         "spec_version": "1_0"
    }
 ~~~
-{: #figspecversionfinal title="Example: spec_version referring to the final 1_0 spec"}
+{: #figspecversionfinal title="Example: spec_version referring to the final 1_0
+spec"}
 
 issuer
 
@@ -783,23 +823,28 @@ delivery_methods_supported
 
 configuration_endpoint
 
-> OPTIONAL. The URL of the Configuration Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
+> OPTIONAL. The URL of the Configuration Endpoint. If present, this URL MUST use
+HTTP over TLS {{RFC9110}}.
 
 status_endpoint
 
-> OPTIONAL. The URL of the Status Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
+> OPTIONAL. The URL of the Status Endpoint. If present, this URL MUST use HTTP
+over TLS {{RFC9110}}.
 
 add_subject_endpoint
 
-> OPTIONAL. The URL of the Add Subject Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
+> OPTIONAL. The URL of the Add Subject Endpoint. If present, this URL MUST use
+HTTP over TLS {{RFC9110}}.
 
 remove_subject_endpoint
 
-> OPTIONAL. The URL of the Remove Subject Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
+> OPTIONAL. The URL of the Remove Subject Endpoint. If present, this URL MUST
+use HTTP over TLS {{RFC9110}}.
 
 verification_endpoint
 
-> OPTIONAL. The URL of the Verification Endpoint. If present, this URL MUST use HTTP over TLS {{RFC9110}}.
+> OPTIONAL. The URL of the Verification Endpoint. If present, this URL MUST use
+HTTP over TLS {{RFC9110}}.
 
 critical_subject_members
 
@@ -809,37 +854,45 @@ critical_subject_members
 authorization_schemes
 
 > OPTIONAL. An array of JSON objects that specify the supported
-  authorization scheme properties defined in {{authorization-scheme}}. To enable seamless discovery of
-  configurations, the service provider SHOULD, with the appropriate
-  security considerations, make the authorization_schemes attribute
+  authorization scheme properties defined in {{authorization-scheme}}. To enable
+  seamless discovery of configurations, the service provider SHOULD, with the
+  appropriate security considerations, make the authorization_schemes attribute
   publicly accessible without prior authentication.
 
 default_subjects
 
-> OPTIONAL. A string indicating the default behavior of newly created streams. If present,
-  the value MUST be either "ALL" or "NONE". If not provided, the Transmitter behavior in
-  this regard is unspecified.
+> OPTIONAL. A string indicating the default behavior of newly created streams.
+  If present, the value MUST be either "ALL" or "NONE". If not provided, the
+  Transmitter behavior in this regard is unspecified.
 >
-> * "ALL" indicates that any subjects that are appropriate for the stream are added to
-    the stream by default. The Receiver MAY remove subjects from the stream via the
-    `remove_subject_endpoint`, causing events for those subjects to _not_ be transmitted.
-    The Receiver MAY re-add any subjects removed this way via the `add_subject_endpoint`.
-> * "NONE" indicates that no subjects are added by default. The Receiver MAY add subjects
-    to the stream via the `add_subject_endpoint`, causing only events for those subjects
-    to be transmitted. The Receiver MAY remove subjects added this way via the
-    `remove_subject_endpoint`.
+> * "ALL" indicates that any subjects that are appropriate for the stream are
+    added to the stream by default. The Receiver MAY remove subjects from the
+    stream via the `remove_subject_endpoint`, causing events for those subjects
+    to _not_ be transmitted. The Receiver MAY re-add any subjects removed this
+    way via the `add_subject_endpoint`.
+> * "NONE" indicates that no subjects are added by default. The Receiver MAY add
+    subjects to the stream via the `add_subject_endpoint`, causing only events
+    for those subjects to be transmitted. The Receiver MAY remove subjects added
+    this way via the `remove_subject_endpoint`.
 
 ### Authorization scheme {#authorization-scheme}
 
-SSF is an HTTP based signals sharing framework and is agnostic to the authentication and authorization schemes used to secure stream configuration APIs. It does not provide any SSF-specific authentication and authorization schemes but relies on the cooperating parties' mutual security considerations.
+SSF is an HTTP based signals sharing framework and is agnostic to the
+authentication and authorization schemes used to secure stream configuration
+APIs. It does not provide any SSF-specific authentication and authorization
+schemes but relies on the cooperating parties' mutual security considerations.
 
-The `authorization_schemes` key of Transmitter Configuration Metadata provides authorization information related to the Transmitter's stream management APIs. These authorization schemes SHOULD also be used to protect any polling endpoint (used for Poll-Based SET delivery [RFC8936]) hosted by the Transmitter.
+The `authorization_schemes` key of Transmitter Configuration Metadata provides
+authorization information related to the Transmitter's stream management APIs.
+These authorization schemes SHOULD also be used to protect any polling endpoint
+(used for Poll-Based SET delivery [RFC8936]) hosted by the Transmitter.
 
 spec_urn
 
 > REQUIRED. A URN that describes the specification of the protocol being used.
 
-The Receiver will call the Transmitter APIs by providing appropriate credentials as per the `spec_urn`.
+The Receiver will call the Transmitter APIs by providing appropriate credentials
+as per the `spec_urn`.
 
 The following is a non-normative example of the `spec_urn`
 
@@ -851,21 +904,21 @@ The following is a non-normative example of the `spec_urn`
 {: #figspecurn title="Example: `spec_urn` specifying the OAuth protocol for authorization"}
 
 In this case, the Receiver may obtain an access token using the Client
-Credentials Grant {{CLIENTCRED}}, or any other method suitable for the Receiver and the
-Transmitter.
+Credentials Grant {{CLIENTCRED}}, or any other method suitable for the Receiver
+and the Transmitter.
 
 ## Obtaining Transmitter Configuration Metadata
 
-Using the Issuer URL as documented by the Transmitter, the Transmitter Configuration
-Metadata can be retrieved. Receivers SHOULD ensure that the Issuer URL comes from a
-trusted source and uses the `https` scheme.
+Using the Issuer URL as documented by the Transmitter, the Transmitter
+Configuration Metadata can be retrieved. Receivers SHOULD ensure that the Issuer
+URL comes from a trusted source and uses the `https` scheme.
 
 Transmitters supporting Discovery MUST make a JSON document available at the
 path formed by inserting the string "/.well-known/ssf-configuration" into the
 Issuer between the host component and the path component, if any. The syntax
 and semantics of ".well-known" are defined in {{RFC8615}}.  "ssf-configuration"
-MUST point to a JSON document compliant with this specification, and that document MUST be
-returned using the "application/json" content type.
+MUST point to a JSON document compliant with this specification, and that
+document MUST be returned using the "application/json" content type.
 
 ### Transmitter Configuration Request
 
@@ -873,26 +926,28 @@ A Transmitter Configuration Document MUST be queried using an HTTP "GET" request
 at the previously specified path.
 
 The Receiver would make the following request to the Issuer
-"https://tr.example.com" to obtain its Transmitter Configuration Metadata, since the
-Issuer contains no path component:
+"https://tr.example.com" to obtain its Transmitter Configuration Metadata, since
+the Issuer contains no path component:
 
 ~~~ http
 GET /.well-known/ssf-configuration HTTP/1.1
 Host: tr.example.com
 ~~~
-{: #figdiscoveryrequest title="Example: Transmitter Configuration Request (without path)"}
+{: #figdiscoveryrequest title="Example: Transmitter Configuration Request
+(without path)"}
 
 If the  Issuer value contains a path component, any terminating "/" MUST be
 removed before inserting "/.well-known/ssf-configuration" between the host
 component and the path component. The Receiver would make the following request
-to the Issuer "https://tr.example.com/issuer1" to obtain its Transmitter Configuration
-Metadata, since the Issuer contains a path component:
+to the Issuer "https://tr.example.com/issuer1" to obtain its Transmitter
+Configuration Metadata, since the Issuer contains a path component:
 
 ~~~ http
 GET /.well-known/ssf-configuration/issuer1 HTTP/1.1
 Host: tr.example.com
 ~~~
-{: #figdiscoveryrequestpath title="Example: Transmitter Configuration Request (with path)"}
+{: #figdiscoveryrequestpath title="Example: Transmitter Configuration Request
+(with path)"}
 
 Using path components enables supporting multiple issuers per host. This is
 required in some multi-tenant hosting configurations. This use of ".well-known"
@@ -913,7 +968,8 @@ making the following request:
 GET /.well-known/risc-configuration HTTP/1.1
 Host: risc-tr.example.com
 ~~~
-{: #figolddiscoveryrequest title="Example: Transmitter Configuration Request for RISC Transmitters"}
+{: #figolddiscoveryrequest title="Example: Transmitter Configuration Request for
+RISC Transmitters"}
 
 ### Transmitter Configuration Response
 
@@ -984,22 +1040,23 @@ Transmitter.
 An Event Stream is an abstraction for how events are communicated from a
 Transmitter to a Receiver. The Event Stream's configuration, which is jointly
 managed by the Transmitter and Receiver, holds information about
-what types of events will be sent from the Transmitter, as well as the mechanism by
-which the Receiver can expect to receive the events. The Event Stream also keeps
-track of what Subjects are of interest to the Receiver, and only events with those
-Subjects are transmitted on the stream.
+what types of events will be sent from the Transmitter, as well as the mechanism
+by which the Receiver can expect to receive the events. The Event Stream also
+keeps track of what Subjects are of interest to the Receiver, and only events
+with those Subjects are transmitted on the stream.
 
 This section defines an HTTP API to be implemented by Event Transmitters
-which can be used by Event Receivers to create and delete one or more Event Streams.
-The API can also be used to query and update the Event Stream's configuration and status,
-add and remove Subjects, and trigger verification for those streams.
+which can be used by Event Receivers to create and delete one or more Event
+Streams. The API can also be used to query and update the Event Stream's
+configuration and status, add and remove Subjects, and trigger verification for
+those streams.
 
-Unless there exists some other method of establishing trust between a Transmitter and
-Receiver, all Stream Management API endpoints MUST use standard HTTP
-authentication and authorization schemes, as per {{RFC9110}}.
-This authorization MUST associate a Receiver with one or more stream IDs and "aud" values,
-such that only authorized Receivers are able to access or modify the details of the
-associated Event Streams.
+Unless there exists some other method of establishing trust between a
+Transmitter and Receiver, all Stream Management API endpoints MUST use standard
+HTTP authentication and authorization schemes, as per {{RFC9110}}. This
+authorization MUST associate a Receiver with one or more stream IDs and "aud"
+values, such that only authorized Receivers are able to access or modify the
+details of the associated Event Streams.
 
 ~~~ascii
 +------------+                +------------+
@@ -1080,86 +1137,97 @@ following properties:
 
 stream_id
 
-> **Transmitter-Supplied**, REQUIRED. A string that uniquely identifies the stream. A
-  Transmitter MUST generate a unique ID for each of its non-deleted streams at the time
-  of stream creation. Transmitters SHOULD use character set described in
-  Section 2.3 of {{RFC3986}} to generate the stream ID.
+> **Transmitter-Supplied**, REQUIRED. A string that uniquely identifies the
+  stream. A Transmitter MUST generate a unique ID for each of its non-deleted
+  streams at the time of stream creation. Transmitters SHOULD use character set
+  described in Section 2.3 of {{RFC3986}} to generate the stream ID.
 
 iss
 
-> **Transmitter-Supplied**, REQUIRED. A URL using the https scheme with no query or
-  fragment component that the Transmitter asserts as its Issuer Identifier. This
-  MUST be identical to the "iss" Claim value in Security Event Tokens issued
-  from this Transmitter.
+> **Transmitter-Supplied**, REQUIRED. A URL using the https scheme with no query
+  or fragment component that the Transmitter asserts as its Issuer Identifier.
+  This MUST be identical to the "iss" Claim value in Security Event Tokens
+  issued from this Transmitter.
 
 aud
 
-> **Transmitter-Supplied**, REQUIRED. A string or an array of strings containing an
-  audience claim as defined in JSON Web Token (JWT){{RFC7519}} that identifies
-  the Event Receiver(s) for the Event Stream. This property cannot be updated.
-  If multiple Receivers are specified then the Transmitter SHOULD know that
-  these Receivers are the same entity.
+> **Transmitter-Supplied**, REQUIRED. A string or an array of strings containing
+  an audience claim as defined in JSON Web Token (JWT){{RFC7519}} that
+  identifies the Event Receiver(s) for the Event Stream. This property cannot be
+  updated. If multiple Receivers are specified then the Transmitter SHOULD know
+  that these Receivers are the same entity.
 
 events_supported
 
-> **Transmitter-Supplied**, OPTIONAL. An array of URIs identifying the set of events
-  supported by the Transmitter for this Receiver. If omitted, Event Transmitters
-  SHOULD make this set available to the Event Receiver via some other means
-  (e.g. publishing it in online documentation).
+> **Transmitter-Supplied**, OPTIONAL. An array of URIs identifying the set of
+  events supported by the Transmitter for this Receiver. If omitted, Event
+  Transmitters SHOULD make this set available to the Event Receiver via some
+  other means (e.g. publishing it in online documentation).
 
 events_requested
 
-> **Receiver-Supplied**, OPTIONAL. An array of URIs identifying the set of events that
-  the Receiver requested. A Receiver SHOULD request only the events that it
-  understands and it can act on. This is configurable by the Receiver. A
+> **Receiver-Supplied**, OPTIONAL. An array of URIs identifying the set of
+  events that the Receiver requested. A Receiver SHOULD request only the events
+  that it understands and it can act on. This is configurable by the Receiver. A
   Transmitter MUST ignore any array values that it does not understand. This
   array SHOULD NOT be empty.
 
 events_delivered
 
-> **Transmitter-Supplied**, REQUIRED. An array of URIs identifying the set of events that
-  the Transmitter MUST include in the stream. This is a subset (not necessarily
-  a proper subset) of the intersection of "events_supported" and
+> **Transmitter-Supplied**, REQUIRED. An array of URIs identifying the set of
+  events that the Transmitter MUST include in the stream. This is a subset (not
+  necessarily a proper subset) of the intersection of "events_supported" and
   "events_requested". A Receiver MUST rely on the values received in this field
   to understand which event types it can expect from the Transmitter.
 
 delivery
 
-> REQUIRED. A JSON object containing a set of name/value pairs specifying configuration
-  parameters for the SET delivery method. The actual delivery method is
-  identified by the special key "method" with the value being a URI as defined
-  in {{delivery-meta}}.
+> REQUIRED. A JSON object containing a set of name/value pairs specifying
+  configuration parameters for the SET delivery method. The actual delivery
+  method is identified by the special key "method" with the value being a URI as
+  defined in {{delivery-meta}}.
 
 min_verification_interval
 
-> **Transmitter-Supplied**, OPTIONAL. An integer indicating the minimum amount of time in
-  seconds that must pass in between verification requests. If an Event Receiver
-  submits verification requests more frequently than this, the Event Transmitter
-  MAY respond with a 429 status code. An Event Transmitter SHOULD NOT respond
-  with a 429 status code if an Event Receiver is not exceeding this frequency.
+> **Transmitter-Supplied**, OPTIONAL. An integer indicating the minimum amount
+  of time in seconds that must pass in between verification requests. If an
+  Event Receiver submits verification requests more frequently than this, the
+  Event Transmitter MAY respond with a 429 status code. An Event Transmitter
+  SHOULD NOT respond with a 429 status code if an Event Receiver is not
+  exceeding this frequency.
 
 description
 
-> **Receiver-Supplied**, OPTIONAL. A string that describes the properties of the stream.
-  This is useful in multi-stream systems to identify the stream for human actors. The
-  transmitter MAY truncate the string beyond an allowed max length.
+> **Receiver-Supplied**, OPTIONAL. A string that describes the properties of the
+  stream. This is useful in multi-stream systems to identify the stream for
+  human actors. The transmitter MAY truncate the string beyond an allowed max
+  length.
 
 inactivity_timeout
 
-> **Transmitter-Supplied**, OPTIONAL. The refreshable inactivity timeout of the stream in seconds. After the timeout duration passes with no eligible activity from the Receiver, as defined below, the Transmitter MAY either pause, disable, or delete the stream. The syntax is the same as that of `expires_in` from Section A.14 of {{RFC6749}}.
+> **Transmitter-Supplied**, OPTIONAL. The refreshable inactivity timeout of the
+stream in seconds. After the timeout duration passes with no eligible activity
+from the Receiver, as defined below, the Transmitter MAY either pause, disable,
+or delete the stream. The syntax is the same as that of `expires_in` from
+Section A.14 of {{RFC6749}}.
 >
-> The following constitutes eligible Receiver activity. If the Transmitter observes any of these activities from the Receiver, it MUST restart the inactivity timeout counter.
+> The following constitutes eligible Receiver activity. If the Transmitter
+observes any of these activities from the Receiver, it MUST restart the
+inactivity timeout counter.
 >
 > > For streams created with the PUSH {{RFC8935}} delivery method:
 > >
-> > * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
+> > * The Receiver calls any endpoint in the Event Stream Management API that
+references the stream ({{management}}).
 > >
 > > For streams created with the POLL {{RFC8936}} delivery method:
 > >
 > > * The Receiver polls the Transmitter for events in the stream.
-> > * The Receiver calls any endpoint in the Event Stream Management API that references the stream ({{management}}).
+> > * The Receiver calls any endpoint in the Event Stream Management API that
+references the stream ({{management}}).
 >
-> If the Transmitter decides to pause or disable the stream, it MUST send a Stream Updated Event to the Receiver as described in {{status}}.
+> If the Transmitter decides to pause or disable the stream, it MUST send a
+Stream Updated Event to the Receiver as described in {{status}}.
 
 #### Creating a Stream {#creating-a-stream}
 
@@ -1167,13 +1235,13 @@ In order to communicate events from a Transmitter to a Receiver, a Receiver
 MUST first create an Event Stream. An Event Receiver creates a stream by making
 an HTTP POST request to the Configuration Endpoint. On receiving a valid request
 the Event Transmitter responds with a "201 Created" response containing a
-JSON {{RFC7159}} representation of the stream’s configuration in the body. The Receiver
-MUST check the response and confirm that the `iss` value matches the Issuer from
-which it received the Transmitter Configuration data.
+JSON {{RFC7159}} representation of the stream’s configuration in the body. The
+Receiver MUST check the response and confirm that the `iss` value matches the
+Issuer from which it received the Transmitter Configuration data.
 
 If a stream already exists, and the Transmitter allows multiple streams with the
 same Receiver, the Event Transmitter MUST respond with a new stream ID. If the
-Transmitter does not allow multiple streams with the same Receiver, it MUST respond
+Transmitter does not allow multiple streams with the same Receiver, it MUST
 respond with HTTP status code "409 Conflict". The Receiver MAY then GET the
 existing stream configuration and, if desired, use PATCH or PUT to update or
 replace the existing stream configuration.
@@ -1186,12 +1254,14 @@ Configuration ({{stream-config}}) object:
 * `description`
 
 If the request does not contain the `delivery` property, then the Transmitter
-MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). If the Transmitter supports
-Poll-Based Delivery, the Transmitter MUST include a `delivery` property in the response with this
-`method` property and an `endpoint_url` property. If the Transmitter does not support
-the delivery method, it MAY respond with HTTP Status Code "400 Bad Request."
+MUST assume that the `method` is "urn:ietf:rfc:8936" (poll). If the Transmitter
+supports Poll-Based Delivery, the Transmitter MUST include a `delivery` property
+in the response with this `method` property and an `endpoint_url` property. If
+the Transmitter does not support the delivery method, it MAY respond with HTTP
+Status Code "400 Bad Request."
 
-Note that in the case of the poll method, the `endpoint_url` value is supplied by the Transmitter.
+Note that in the case of the poll method, the `endpoint_url` value is supplied
+by the Transmitter.
 
 The following is a non-normative example request to create an Event Stream:
 
@@ -1265,16 +1335,17 @@ Errors are signaled with HTTP status codes as follows:
 
 * `aud`: the Receiver SHOULD validate the `aud` in the Create Stream Response.
 A Transmitter and Receiver MAY agree upon the audience value out of band.
-Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure that it matches what it expects.
+Regardless of how the audience value is agreed upon, the Receiver SHOULD ensure
+that it matches what it expects.
 
 #### Reading a Stream’s Configuration {#reading-a-streams-configuration}
 
 An Event Receiver gets the current configuration of a stream by making an HTTP
 GET request to the Configuration Endpoint. On receiving a valid request, the
-Event Transmitter responds with a "200 OK" response containing a JSON {{RFC7159}}
-representation of the stream’s configuration in the body.  The Receiver
-MUST check the response and confirm that the `iss` value matches the Issuer from
-which it received the Transmitter Configuration data.
+Event Transmitter responds with a "200 OK" response containing a JSON
+{{RFC7159}} representation of the stream’s configuration in the body. The
+Receiver MUST check the response and confirm that the `iss` value matches the
+Issuer from which it received the Transmitter Configuration data.
 
 The GET request MAY include the "stream_id" as a query parameter in order to
 identify the correct Event Stream. If the "stream_id" parameter is missing,
@@ -1339,7 +1410,8 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 ~~~
 {: title="Example: Read Stream Configuration Request" #figreadconfigreqnostreamid}
 
-The following is a non-normative example response to a request with no "stream_id":
+The following is a non-normative example response to a request with no
+"stream_id":
 
 ~~~ http
 HTTP/1.1 200 OK
@@ -1443,8 +1515,8 @@ Cache-Control: no-store
 ~~~
 {: title="Example: Read Stream Configuration Response" #figreadconfigrespnostreamidonestream}
 
-The following is a non-normative example response to a request with no "stream_id"
-when there are no Event Streams configured:
+The following is a non-normative example response to a request with no
+"stream_id" when there are no Event Streams configured:
 
 ~~~ http
 HTTP/1.1 200 OK
@@ -1468,22 +1540,24 @@ Errors are signaled with HTTP status codes as follows:
 
 An Event Receiver updates the current configuration of a stream by making an
 HTTP PATCH request to the Configuration Endpoint. The PATCH body contains a
-JSON {{RFC7159}} representation of the stream configuration properties to change. On
-receiving a valid request, the Event Transmitter responds with a "200 OK"
-response containing a JSON {{RFC7159}} representation of the entire updated stream
-configuration in the body. The Receiver MUST check the response and confirm that the
-`iss` value matches the Issuer from which it received the Transmitter Configuration data.
+JSON {{RFC7159}} representation of the stream configuration properties to
+change. On receiving a valid request, the Event Transmitter responds with a
+"200 OK" response containing a JSON {{RFC7159}} representation of the entire
+updated stream configuration in the body. The Receiver MUST check the response
+and confirm that the `iss` value matches the Issuer from which it received the
+Transmitter Configuration data.
 
 The stream_id property MUST be present in the request. Other properties
 MAY be present in the request. Any Receiver-Supplied property present in the
 request MUST be updated by the Transmitter. Any properties missing in the
-request MUST NOT be changed by the Transmitter. If `events_requested` property is
-included in the request, it SHOULD NOT be an empty array.
+request MUST NOT be changed by the Transmitter. If `events_requested` property
+is included in the request, it SHOULD NOT be an empty array.
 
 Transmitter-Supplied properties besides the stream_id MAY be present,
 but they MUST match the expected value. Missing Transmitter-Supplied
 properties MUST be ignored by the Transmitter. The `events_delivered` property,
-if present, MUST match the Transmitter's expected value before any updates are applied.
+if present, MUST match the Transmitter's expected value before any updates are
+applied.
 
 The following is a non-normative example request to replace an Event Stream’s
 configuration:
@@ -1567,13 +1641,15 @@ The stream_id and the full set of Receiver-Supplied properties MUST be present
 in the PUT body, not only those specifically intended to be changed.
 Missing Receiver-Supplied properties MUST be interpreted as requested to be
 deleted. Event Receivers MAY read the configuration first, modify the JSON
-{{RFC7159}} representation, then make a replacement request. If `events_requested`
-property is included in the request, it SHOULD NOT be an empty array.
+{{RFC7159}} representation, then make a replacement request. If
+`events_requested` property is included in the request, it SHOULD NOT be an
+empty array.
 
 Transmitter-Supplied properties besides the stream_id MAY be present,
 but they MUST match the expected value. Missing Transmitter-Supplied
 properties MUST be ignored by the Transmitter. The `events_delivered` property,
-if present, MUST match the Transmitter's expected value _before_ any updates are applied.
+if present, MUST match the Transmitter's expected value _before_ any updates are
+applied.
 
 The following is a non-normative example request to replace an Event Stream’s
 configuration:
@@ -1651,7 +1727,8 @@ Pending conditions or errors are signaled with HTTP status codes as follows:
 
 An Event Receiver deletes a stream by making an HTTP DELETE request to the
 Configuration Endpoint. On receiving a request, the Event Transmitter responds
-with an empty "204 No Content" response if the configuration was successfully removed.
+with an empty "204 No Content" response if the configuration was successfully
+removed.
 
 The DELETE request MUST include the "stream_id" as a query parameter in order to
 identify the correct Event Stream.
@@ -1684,11 +1761,12 @@ Errors are signaled with HTTP status codes as follows:
 
 ### Stream Status {#status}
 
-Event Streams are managed independently. A Receiver MAY request that events from a
-stream be interrupted by Updating the Stream Status ({{updating-a-streams-status}}).
-If a Transmitter decides to enable, pause or disable updates from a stream
-independently of an update request from a Receiver, it MUST send a Stream Updated Event
-({{stream-updated-event}}) to the Receiver.
+Event Streams are managed independently. A Receiver MAY request that events from
+a stream be interrupted by Updating the Stream Status
+({{updating-a-streams-status}}). If a Transmitter decides to enable, pause or
+disable updates from a stream independently of an update request from a
+Receiver, it MUST send a Stream Updated Event ({{stream-updated-event}}) to the
+Receiver.
 
 #### Reading a Stream’s Status {#reading-a-streams-status}
 
@@ -1714,8 +1792,8 @@ status
 
 reason
 
-> An OPTIONAL string whose value SHOULD express why the stream's status is set to
-the current value.
+> An OPTIONAL string whose value SHOULD express why the stream's status is set
+to the current value.
 
 The allowable "status" values are:
 
@@ -1823,8 +1901,8 @@ Authorization: Bearer eyJ0b2tlbiI6ImV4YW1wbGUifQo=
 ~~~
 {: title="Example: Update Stream Status Request Without Optional Fields" #figupdatestatusreq}
 
-The following is a non-normative example of an Update Stream Status request with an
-optional reason:
+The following is a non-normative example of an Update Stream Status request with
+an optional reason:
 
 ~~~ http
 POST /ssf/status HTTP/1.1
@@ -1867,9 +1945,9 @@ Errors are signaled with HTTP status codes as follows:
 
 Examples:
 
-1. If a Receiver makes a request to update a stream status, and the Transmitter is
-   unable to decide whether or not to complete the request, then the Transmitter MUST
-   respond with a 202 status code.
+1. If a Receiver makes a request to update a stream status, and the Transmitter
+   is unable to decide whether or not to complete the request, then the
+   Transmitter MUST respond with a 202 status code.
 
 ### Subjects {#subjects}
 
@@ -1879,12 +1957,13 @@ Receiver wants to receive events about a particular subject by “adding” or
 
 #### Subject Matching {#subject-matching}
 
-If a Receiver adds a subject to a stream defined in {{adding-a-subject-to-a-stream}}, the Transmitter SHOULD send any events
-relating to the subject which have event_types that the Receiver has subscribed to,
-as long as the stream status is enabled. In the case of Simple Subjects,
-two subjects match if they are exactly identical. For Complex Subjects, two subjects
-match if, for all fields in the Complex Subject (i.e. `user`, `group`, `device`, etc.),
-at least one of the following statements is true:
+If a Receiver adds a subject to a stream defined in
+{{adding-a-subject-to-a-stream}}, the Transmitter SHOULD send any events
+relating to the subject which have event_types that the Receiver has subscribed
+to, as long as the stream status is enabled. In the case of Simple Subjects, two
+subjects match if they are exactly identical. For Complex Subjects, two subjects
+match if, for all fields in the Complex Subject (i.e. `user`, `group`, `device`,
+etc.), at least one of the following statements is true:
 
 1. Subject 1's field is not defined
 
@@ -1892,9 +1971,9 @@ at least one of the following statements is true:
 
 3. Subject 1's field is identical to Subject 2's field
 
-The following is a non-normative example of subject matching for Complex Subjects
-when a Receiver adds a subject that is less restrictive than the subject being sent
-by the Transmitter.
+The following is a non-normative example of subject matching for Complex
+Subjects when a Receiver adds a subject that is less restrictive than the
+subject being sent by the Transmitter.
 
 The Receiver has added the following subject to their stream:
 
@@ -1924,12 +2003,12 @@ The Transmitter has an event to broadcast with the following subject:
 }
 ~~~
 
-According to the matching rules described above, the Transmitter SHOULD broadcast the
-event over the Receiver's stream.
+According to the matching rules described above, the Transmitter SHOULD
+broadcast the event over the Receiver's stream.
 
-The following is a non-normative example of subject matching for Complex Subjects
-when a Receiver adds a subject that is more restrictive than the subject being sent
-by the Transmitter.
+The following is a non-normative example of subject matching for Complex
+Subjects when a Receiver adds a subject that is more restrictive than the
+subject being sent by the Transmitter.
 
 The Receiver has added the following subject to their stream:
 
@@ -1959,10 +2038,11 @@ The Transmitter has an event to broadcast with the following subject:
 }
 ~~~
 
-According to the matching rules described above, the Transmitter SHOULD broadcast the
-event over the Receiver's stream.
+According to the matching rules described above, the Transmitter SHOULD
+broadcast the event over the Receiver's stream.
 
-The following is a non-normative example of two Complex Subjects that do not match.
+The following is a non-normative example of two Complex Subjects that do not
+match.
 
 The Receiver has added the following subject to their stream:
 
@@ -1996,8 +2076,8 @@ The Transmitter has an event to broadcast with the following subject:
 }
 ~~~
 
-According to the matching rules described above, the Transmitter SHOULD NOT broadcast the
-event over the Receiver's stream.
+According to the matching rules described above, the Transmitter SHOULD NOT
+broadcast the event over the Receiver's stream.
 
 #### Adding a Subject to a Stream {#adding-a-subject-to-a-stream}
 
@@ -2074,7 +2154,8 @@ with the following claims:
 
 stream_id
 
-> REQUIRED. A string identifying the stream from which the subject is being removed.
+> REQUIRED. A string identifying the stream from which the subject is being
+removed.
 
 subject
 
@@ -2135,11 +2216,15 @@ delivery is working, including signature verification and encryption.
 A Transmitter MAY send a Verification Event at any time, even if one was
 not requested by the Event Receiver.
 
-A Transmitter MAY respond to Verification Event requests even if the event is not present in the `events_supported`, `events_requested` and / or `events_delivered` fields in the Stream Configuration ({{stream-config}}).
+A Transmitter MAY respond to Verification Event requests even if the event is
+not present in the `events_supported`, `events_requested` and / or
+`events_delivered` fields in the Stream Configuration ({{stream-config}}).
 
 #### Verification Event {#verification-event}
 
-The Verification Event is an SSF event with the event type: "https://schemas.openid.net/secevent/ssf/event-type/verification". The event contains the following attribute:
+The Verification Event is an SSF event with the event type:
+"https://schemas.openid.net/secevent/ssf/event-type/verification". The event
+contains the following attribute:
 
 state
 
@@ -2150,7 +2235,9 @@ As with any SSF event, the Verification Event has a top-level `sub_id` claim:
 
 sub_id
 
-> REQUIRED. The value of the top-level `sub_id` claim in a Verification Event MUST always be set to have a simple value of type `opaque`. The `id` of the value MUST be the `stream_id` of the stream being verified.
+> REQUIRED. The value of the top-level `sub_id` claim in a Verification Event
+MUST always be set to have a simple value of type `opaque`. The `id` of the
+value MUST be the `stream_id` of the stream being verified.
 >
 > Note that the subject that identifies a stream itself is always implicitly
   added to the stream and MAY NOT be removed from the stream.
@@ -2158,8 +2245,8 @@ sub_id
 Upon receiving a Verification Event, the Event Receiver SHALL parse the SET and
 validate its claims. In particular, the Event Receiver SHALL confirm that the
 value for "state" is as expected. If the value of "state" does not match, an
-error response with the "err" field set to "invalid_state" SHOULD be returned (see Section 2.4 of
-{{RFC8935}} or Section 2.4.4 of {{RFC8936}}).
+error response with the "err" field set to "invalid_state" SHOULD be returned
+(see Section 2.4 of {{RFC8935}} or Section 2.4.4 of {{RFC8936}}).
 
 In many cases, Event Transmitters MAY disable or suspend an Event Stream that
 fails to successfully verify based on the acknowledgement or lack of
@@ -2168,44 +2255,46 @@ acknowledgement by the Event Receiver.
 #### Triggering a Verification Event. {#triggering-a-verification-event}
 
 To request that a Verification Event be sent over an Event Stream, the Event
-Receiver makes an HTTP POST request to the Verification Endpoint, with a [JSON]
-[RFC7159] object containing the parameters of the verification request, if any.
-On a successful request, the Event Transmitter responds with an empty
+Receiver makes an HTTP POST request to the Verification Endpoint, with a JSON
+{{RFC7159}} object containing the parameters of the verification request, if
+any. On a successful request, the Event Transmitter responds with an empty
 "204 No Content" response.
 
 Verification requests have the following properties:
 
 stream_id
 
-> REQUIRED. A string identifying the stream that the Verification Event is being requested on.
+> REQUIRED. A string identifying the stream that the Verification Event is being
+requested on.
 
 state
 
 > OPTIONAL. An arbitrary string that the Event Transmitter MUST echo back to the
   Event Receiver in the Verification Event’s payload. Event Receivers MAY use
   the value of this parameter to correlate a Verification Event with a
-  verification request. If the Verification Event is initiated by the Transmitter
-  then this parameter MUST not be set.
+  verification request. If the Verification Event is initiated by the
+  Transmitter then this parameter MUST not be set.
 
 A successful response from a POST to the Verification Endpoint does not indicate
 that the Verification Event was transmitted successfully, only that the Event
 Transmitter has transmitted the event or will do so at some point in the future.
-Event Transmitters MAY transmit the event via an asynchronous process, and SHOULD
-publish an SLA for Verification Event transmission times. Event Receivers MUST NOT
-depend on the Verification Event being transmitted synchronously or in any
-particular order relative to the current queue of events.
+Event Transmitters MAY transmit the event via an asynchronous process, and
+SHOULD publish an SLA for Verification Event transmission times. Event Receivers
+MUST NOT depend on the Verification Event being transmitted synchronously or in
+any particular order relative to the current queue of events.
 
 Errors are signaled with HTTP status codes as follows:
 
 | Code | Description |
 |------|-------------|
-| 400  | if the request body cannot be parsed or if the request is otherwise invalid |
+| 400  | if the request body cannot be parsed or if the request is otherwiseinvalid |
 | 401  | if authorization failed or it is missing |
 | 404  | if there is no Event Stream with the given "stream_id" for this Event Receiver |
 | 429  | if the Event Receiver is sending too many requests in a given amount of time; see related "min_verification_interval" in {{stream-config}}
 {: title="Verification Errors" #taberifyerr}
 
-The following is a non-normative example request to trigger a Verification Event:
+The following is a non-normative example request to trigger a Verification
+Event:
 
 ~~~ http
 POST /ssf/verify HTTP/1.1
@@ -2266,7 +2355,9 @@ If the Transmitter changes the status of the stream from either
 "paused" or "disabled" to "enabled", then it MUST send this event to the
 Receiver upon re-enabling the stream.
 
-A Transmitter MAY send a Stream Updated event even if the event is not present in the `events_supported`, `events_requested` and / or `events_delivered` fields in the Stream Configuration ({{stream-config}}).
+A Transmitter MAY send a Stream Updated event even if the event is not present
+in the `events_supported`, `events_requested` and / or `events_delivered` fields
+in the Stream Configuration ({{stream-config}}).
 
 The "stream-updated" event contains the following claims:
 
@@ -2283,7 +2374,9 @@ As with any SSF event, this event has a top-level `sub_id` claim:
 
 sub_id
 
-> REQUIRED. The top-level `sub_id` claim specifies the Stream Id for which the status has been updated. The value of the `sub_id` field MUST be of format `opaque`, and its `id` value MUST be the unique ID of the stream.
+> REQUIRED. The top-level `sub_id` claim specifies the Stream Id for which the
+status has been updated. The value of the `sub_id` field MUST be of format
+`opaque`, and its `id` value MUST be the unique ID of the stream.
 >
 > Note that the subject that identifies a stream itself is always implicitly
   added to the stream and MAY NOT be removed from the stream.
@@ -2348,10 +2441,10 @@ are outside the scope of this specification.
 
 A malicious party may find it advantageous to remove a particular subject from a
 stream, in order to reduce the Event Receiver’s ability to detect malicious
-activity related to the subject, inconvenience the subject, or for other reasons.
-Consequently it may be in the best interests of the subject for the Event
-Transmitter to continue to send events related to the subject for some time after
-the subject has been removed from a stream.
+activity related to the subject, inconvenience the subject, or for other
+reasons. Consequently it may be in the best interests of the subject for the
+Event Transmitter to continue to send events related to the subject for some
+time after the subject has been removed from a stream.
 
 Event Transmitters MAY continue sending events related to a subject for some
 amount of time after that subject has been removed from the stream. Event
@@ -2363,15 +2456,15 @@ Transmitter.
 
 ## Subject Information Leakage {#sub-info-leakage}
 
-Event Transmitters and Receivers SHOULD take precautions to ensure that they do not
-leak information about subjects via Subject Identifiers, and choose appropriate
-Subject Identifier Types accordingly. Parties SHOULD NOT identify a subject
-using a given Subject Identifier Type if doing so will allow the recipient to
-correlate different claims about the subject that they are not known to already
-have knowledge of. Transmitters and Receivers SHOULD always use the same Subject
-Identifier Type and the same claim values to identify a given subject when
-communicating with a given party in order to reduce the possibility of
-information leakage.
+Event Transmitters and Receivers SHOULD take precautions to ensure that they do
+not leak information about subjects via Subject Identifiers, and choose
+appropriate Subject Identifier Types accordingly. Parties SHOULD NOT identify a
+subject using a given Subject Identifier Type if doing so will allow the
+recipient to correlate different claims about the subject that they are not
+known to already have knowledge of. Transmitters and Receivers SHOULD always use
+the same Subject Identifier Type and the same claim values to identify a given
+subject when communicating with a given party in order to reduce the possibility
+of information leakage.
 
 ## Previously Consented Data {#previously-consented-data}
 
@@ -2388,8 +2481,8 @@ or data whose consent to exchange has expired has the following considerations:
 
 ### Organizational Data {#organizational-data}
 
-If a user has previously agreed with a Transmitter that they allow the release of
-certain data to third-parties, then the Transmitter MAY send such data in SSF
+If a user has previously agreed with a Transmitter that they allow the release
+of certain data to third-parties, then the Transmitter MAY send such data in SSF
 events without additional consent of the user. Such data MAY include
 organizational data about the Subject Principal that was generated by the
 Transmitter.
@@ -2407,13 +2500,13 @@ Subject Identifiers defined in this document will be added to the "Security
 Events Subject Identifier Types" registry. This registry is defined in the
 Subject Identifiers for Security Event Tokens {{RFC9493}} specification.
 
-The `ssf-configuration` well-known endpoint is registered in IANA's Well-Known URIs
-registry, as defined by {{RFC8615}}.
+The `ssf-configuration` well-known endpoint is registered in IANA's Well-Known
+URIs registry, as defined by {{RFC8615}}.
 
-IANA is asked to assign the error code "invalid_state", as defined in {{verification-event}}, to the
-Security Event Token Error Codes section of the Security Event Token registry, as defined
-in Section 7.1 of {{RFC8935}}. The following information is provided as required by the
-registration template:
+IANA is asked to assign the error code "invalid_state", as defined in
+{{verification-event}}, to the Security Event Token Error Codes section of the
+Security Event Token registry, as defined in Section 7.1 of {{RFC8935}}. The
+following information is provided as required by the registration template:
 
 Error Code
 
@@ -2440,9 +2533,34 @@ specification.
 
 Copyright (c) 2024 The OpenID Foundation.
 
-The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer, or other interested party a non-exclusive, royalty free, worldwide copyright license to reproduce, prepare derivative works from, distribute, perform and display, this Implementers Draft or Final Specification solely for the purposes of (i) developing specifications, and (ii) implementing Implementers Drafts and Final Specifications based on such documents, provided that attribution be made to the OIDF as the source of the material, but that such attribution does not indicate an endorsement by the OIDF.
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright
+license to reproduce, prepare derivative works from, distribute, perform and
+display, this Implementers Draft or Final Specification solely for the purposes
+of (i) developing specifications, and (ii) implementing Implementers Drafts and
+Final Specifications based on such documents, provided that attribution be made
+to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
 
-The technology described in this specification was made available from contributions from various sources, including members of the OpenID Foundation and others. Although the OpenID Foundation has taken steps to help ensure that the technology is available for distribution, it takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this specification or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any independent effort to identify any such rights. The OpenID Foundation and the contributors to this specification make no (and hereby expressly disclaim any) warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to this specification, and the entire risk as to implementing this specification is assumed by the implementer. The OpenID Intellectual Property Rights policy requires contributors to offer a patent promise not to assert certain patent claims against other contributors and against implementers. The OpenID Foundation invites any interested party to bring to its attention any copyrights, patents, patent applications, or other proprietary rights that may cover technology that may be required to practice this specification.
+The technology described in this specification was made available from
+contributions from various sources, including members of the OpenID Foundation
+and others. Although the OpenID Foundation has taken steps to help ensure that
+the technology is available for distribution, it takes no position regarding the
+ validity or scope of any intellectual property or other rights that might be
+ claimed to pertain to the implementation or use of the technology described in
+ this specification or the extent to which any license under such rights might
+ or might not be available; neither does it represent that it has made any
+ independent effort to identify any such rights. The OpenID Foundation and the
+ contributors to this specification make no (and hereby expressly disclaim any)
+ warranties (express, implied, or otherwise), including implied warranties of
+ merchantability, non-infringement, fitness for a particular purpose, or title,
+ related to this specification, and the entire risk as to implementing this
+ specification is assumed by the implementer. The OpenID Intellectual Property
+ Rights policy requires contributors to offer a patent promise not to assert
+ certain patent claims against other contributors and against implementers. The
+ OpenID Foundation invites any interested party to bring to its attention any
+ copyrights, patents, patent applications, or other proprietary rights that may
+ cover technology that may be required to practice this specification.
 
 # Document History
 
@@ -2450,18 +2568,30 @@ The technology described in this specification was made available from contribut
 
 -20
 
-* Clarified that Transmitters may drop events if they aren't able to deliver them to the receiver.
-* Added examples to demonstrate how "wildcard matching" works in SSF event complex subjects
-* Added an `inactivity_timeout` field to the Transmitter metadata, after which transmitters may pause, disable or delete inactive streams.
+* Clarified that Transmitters may drop events if they aren't able to deliver
+them to the receiver.
+* Added examples to demonstrate how "wildcard matching" works in SSF event
+complex subjects
+* Added an `inactivity_timeout` field to the Transmitter metadata, after which
+transmitters may pause, disable or delete inactive streams.
 * Clarified that Receivers should validate the `aud` value
-* Clarified that Transmitters may include additional fields in SSF events, and how receivers should interpret them.
+* Clarified that Transmitters may include additional fields in SSF events, and
+how receivers should interpret them.
 * Specified that the poll delivery endpoint should require authorization
-* Clarified stream creation behavior for delivery method mismatch and poll delivery
-* Clarified that StreamIDs have to be of the "unreserved characters" character set from RFC3986
+* Clarified stream creation behavior for delivery method mismatch and poll
+delivery
+* Clarified that StreamIDs have to be of the "unreserved characters" character
+set from RFC3986
 * Clarified the authorization_header requirement for the receiver
-* Rearranged the content for easier readability: Eliminated the "Profiles" section (previous section 10). Created new sections "Events" (new section 4), and "Event Delivery" (new Section 6). Incorporated text from the erstwhile "Profiles" section into other sections as appropriate. Fixed references and titles of examples.
+* Rearranged the content for easier readability: Eliminated the "Profiles"
+section (previous section 10). Created new sections "Events" (new section 4),
+and "Event Delivery" (new Section 6). Incorporated text from the erstwhile
+"Profiles" section into other sections as appropriate. Fixed references and
+titles of examples.
 * Added "IP Address" as a subject identifier format
-* In Create Stream, specified that description may be included in the response, and that the `endpoint_url` is specified by the Transmitter in the `poll` delivery method
+* In Create Stream, specified that description may be included in the response,
+and that the `endpoint_url` is specified by the Transmitter in the `poll`
+delivery method
 * Updated URLs of linked specs and other resources
 * Fixed example to have correct format for "reason_admin" and "reason_user"
 
@@ -2472,30 +2602,37 @@ The technology described in this specification was made available from contribut
 * Add stream_id to the response when getting stream status
 * Update subject/sub_id in examples. Fix CAEP example
 * Clarify language around sending Stream Updated events
-* Add sentence suggesting that Issuer information should be validated by the Receiver
+* Add sentence suggesting that Issuer information should be validated by the
+Receiver
 * Removed cause-time from RISC example
 * Fix description of error code for invalid state
 * Add SHOULD language about checking the issuer value
 * Added language requiring authorization of stream management API
 * Added description of `txn` claim
-* Added a `default_subjects` field to Transmitter Configuration Metadata indicating expected subject behavior for new streams
-* added txn claims to non-normative SET examples and generic txn callout under SET Profile section RFC8417
+* Added a `default_subjects` field to Transmitter Configuration Metadata
+indicating expected subject behavior for new streams
+* added txn claims to non-normative SET examples and generic txn callout under
+SET Profile section RFC8417
 * Editorial: Standardize terms and casing, fix some typos
 
 -02
 
 * added spec version to metadata
 * Added description as receiver supplied
-* added language to make verification and updated events independent of events_supported
-* added top-level sub_id claim. Modified existing language to reflect the use of the sub_id claim
-* updated text to reflect sub_id as a top-level field in verification and stream updated events
+* added language to make verification and updated events independent of
+events_supported
+* added top-level sub_id claim. Modified existing language to reflect the use of
+the sub_id claim
+* updated text to reflect sub_id as a top-level field in verification and stream
+updated events
 * \#46 add stream exists behavior
 * update stream exists to 409
 * Add 'format' to normative examples in CAEP
 * Remove 'format' from stream config
 * Remove subject from stream status (#88)
 * Add reason to GET /status response
-* Make reason look like an enum in the example to indicate how we expect it to be used
+* Make reason look like an enum in the example to indicate how we expect it to
+be used
 * Fixes \#60 - are subjects required
 * Added format field to complex subjects and updated examples (#71)
 * Switch stray '204 OK' to read '204 No Content' (#73)
@@ -2506,14 +2643,17 @@ The technology described in this specification was made available from contribut
 * Sse to ssf (#43)
 * updated SSE to Shared Signals in all files
 * changed source format to md
-* renamed files to be called sharedsignals instead of SSE. No change to the content (#41)
-* Add stream_id to SSE Framework spec as per Issue 4: https://github.com/openid/sse/issues/4
+* renamed files to be called sharedsignals instead of SSE. No change to the
+content (#41)
+* Add stream_id to SSE Framework spec as per Issue 4:
+https://github.com/openid/sse/issues/4
 * Update README with development instructions and fix error in Makefile
 * Added note to PUSH/POLL section about uniqueness requirements for the URLs
 * Add explanation about what an Event Stream is
 * Change terms to Transmitter-Supplied and Receiver-Supplied
 * Pragma is an obsolete HTTP header
 * It's unnecessary to specify the character as UTF-8 in all examples (#10)
-* Fix issue \#18 by converting saml-assertion-id to saml_assertion_id to maintain consistent formatting with other subject identifiers (#1)
+* Fix issue \#18 by converting saml-assertion-id to saml_assertion_id to
+maintain consistent formatting with other subject identifiers (#1)
 * updated backward compatibility language
 * added section for Transmitter Configuration Metadata RISC compatibility

--- a/working-group-charter.md
+++ b/working-group-charter.md
@@ -1,98 +1,184 @@
 # Shared Signals Working Group Charter
+
 ## 1) Working Group Name
+
 Shared Signals
 
 ## 2) Purpose
-The goal of the Shared Signals Working Group is to enable the sharing of security events, state changes, and other signals between related and/or dependent systems in order to:
-* Manage access to resources and enforce access control restrictions across distributed services operating in a dynamic environment.
-* Prevent malicious actors from leveraging compromises of accounts, devices, services, endpoints, or other principals or resources to gain unauthorized access to additional systems or resources.
-* Enable users, administrators, and service providers to coordinate in order to detect and respond to incidents.
+
+The goal of the Shared Signals Working Group is to enable the sharing of
+security events, state changes, and other signals between related and/or
+dependent systems in order to:
+
+* Manage access to resources and enforce access control restrictions across
+distributed services operating in a dynamic environment.
+* Prevent malicious actors from leveraging compromises of accounts, devices,
+services, endpoints, or other principals or resources to gain unauthorized
+access to additional systems or resources.
+* Enable users, administrators, and service providers to coordinate in order to
+detect and respond to incidents.
 
 ## 3) Scope
+
 The group will define:
 
 * **Security events**
-  * These are events – whether directly authentication or authorization-related or occurring at another time in the user flow – that one party becomes aware of and that may have security implications for other parties. The group will develop a taxonomy of security events and a common set of semantics to express relevant information about a security event, and recommended actions to take in response to an event.
+  * These are events – whether directly authentication or authorization-related
+  or occurring at another time in the user flow – that one party becomes aware
+  of and that may have security implications for other parties. The group will
+  develop a taxonomy of security events and a common set of semantics to express
+  relevant information about a security event, and recommended actions to take
+  in response to an event.
 * **Privacy implications**
-  * Sharing security information amongst providers has potential privacy implications for both end users and service providers. These privacy implications must be considered against both (a) applicable regulations, policies, and the principles of user notice, choice and consent, and (b) the recognized benefits of protecting users’ accounts and data from abuse. The group will consider ways to address such potential privacy implications when defining mechanisms to handle the various security events and recommend best practices for the industry.
+  * Sharing security information amongst providers has potential privacy
+  implications for both end users and service providers. These privacy
+  implications must be considered against both (a) applicable regulations,
+  policies, and the principles of user notice, choice and consent, and (b) the
+  recognized benefits of protecting users’ accounts and data from abuse. The
+  group will consider ways to address such potential privacy implications when
+  defining mechanisms to handle the various security events and recommend best
+  practices for the industry.
 * **Communications mechanisms**
-  * The group will define bindings for the use of existing transport and event stream management protocols defined elsewhere, and define new protocols as needed to meet technical requirements identified by the group.
+  * The group will define bindings for the use of existing transport and event
+  stream management protocols defined elsewhere, and define new protocols as
+  needed to meet technical requirements identified by the group.
 * **Trust frameworks**
-  * The group will define at least one model for the conditions under which information would be shared.
+  * The group will define at least one model for the conditions under which
+  information would be shared.
 * **Account recovery mechanisms**
-  * The group will define standardized mechanism(s) to allow providers to signal that a user has regained control of an account, or allow a user to explicitly restore control of a previously compromised account, with or without direct user involvement.
+  * The group will define standardized mechanism(s) to allow providers to signal
+  that a user has regained control of an account, or allow a user to explicitly
+  restore control of a previously compromised account, with or without direct
+  user involvement.
 * **Best practices**
-  * Where specifications allow for a wide range of implementations, the group will provide recommended best practices on how to implement specifications safely and securely, and how to mitigate known threats.
+  * Where specifications allow for a wide range of implementations, the group
+  will provide recommended best practices on how to implement specifications
+  safely and securely, and how to mitigate known threats.
 
-### Out of scope:
-* Determining the account quality/reputation of a user on a particular service and communicating that to others.
-* Definition of APIs and underlying mechanisms for connecting to, interacting with and operating centralized databases or intelligence clearinghouses when these are used to communicate security events between account providers.
+### Out of scope
+
+* Determining the account quality/reputation of a user on a particular service
+and communicating that to others.
+* Definition of APIs and underlying mechanisms for connecting to, interacting
+with and operating centralized databases or intelligence clearinghouses when
+these are used to communicate security events between account providers.
 
 ## 4) Proposed Deliverables
+
 The group proposes the following **Non-Specification** deliverables:
 
 * **Security Event and Account Lifecycle Schema**
-  * A taxonomy of security events and a common set of semantics to express relevant information about a security event and its relationships to other relevant data, events or indicators.
+  * A taxonomy of security events and a common set of semantics to express
+  relevant information about a security event and its relationships to other
+  relevant data, events or indicators.
 * **Security Event Privacy Guidelines**
-  * A set of recommendations on how to minimize the privacy impact on users and service providers while improving security, and how to provide appropriate privacy disclosures, labeling and access control guidelines around information in the Security Event Schema.
+  * A set of recommendations on how to minimize the privacy impact on users and
+  service providers while improving security, and how to provide appropriate
+  privacy disclosures, labeling and access control guidelines around information
+  in the Security Event Schema.
 * **Trust Framework**
-  * A trust framework defining roles and responsibilities of parties sharing user security event information
+  * A trust framework defining roles and responsibilities of parties sharing
+  user security event information
 
 The group proposes the following **Specification** deliverables:
 
 * **Communications Mechanisms**
-  * Define bindings for the event messages to an already existing transport protocol to promote interoperability of sending event information to another Service Provider. This will allow a Service Provider to implement a single piece of infrastructure that would be able to send or receive event information to any other service provider.
+  * Define bindings for the event messages to an already existing transport
+  protocol to promote interoperability of sending event information to another
+  Service Provider. This will allow a Service Provider to implement a single
+  piece of infrastructure that would be able to send or receive event
+  information to any other service provider.
 * **RISC Event Schema**
-  * Define an extensible set of security events related to state changes that can occur within the user account lifecycle.
+  * Define an extensible set of security events related to state changes that
+  can occur within the user account lifecycle.
 * **CAEP Event Schema**
-  * Define an extensible set of security events related to state changes or other context changes that may impact the security posture of a user, device, app, client, or other context.
+  * Define an extensible set of security events related to state changes or
+  other context changes that may impact the security posture of a user, device,
+  app, client, or other context.
 
 ### Order of Deliverables
-The group will work to produce the Security Event and Account Lifecycle Schema before beginning work on the Communications Mechanism or Trust Framework.
+
+The group will work to produce the Security Event and Account Lifecycle Schema
+before beginning work on the Communications Mechanism or Trust Framework.
 
 ## 5) Anticipated audience or users
-* Service providers who manage their own account systems which require an email address or phone number for registration.
-* Account and email providers that understand key security events that happen to a user’s account.
-* Identity as a Service (IDaaS) vendors that manage account and authentication systems for their customers.
+
+* Service providers who manage their own account systems which require an email
+address or phone number for registration.
+* Account and email providers that understand key security events that happen to
+a user’s account.
+* Identity as a Service (IDaaS) vendors that manage account and authentication
+systems for their customers.
 * Users seeking to regain control of a compromised account.
 * Identity providers.
-* Application and Software as a Service (SaaS) vendors that support identity federation.
+* Application and Software as a Service (SaaS) vendors that support identity
+federation.
 * Software vendors operating in highly regulated verticals.
 * VPN server and network hardware vendors.
 * Administrators of systems operating under a zero-trust security model.
 * Cloud Access Security Brokers.
 
 ## 6) Language
+
 * English
 
-## 7) Method of work:
-* E-mail discussions on the working group mailing list, working group conference calls, and face-to-face meetings from time to time.
+## 7) Method of work
 
-## 8) Basis for determining when the work is completed:
-* Rough consensus and running code. The work will be completed once it is apparent that maximal consensus on the draft has been achieved, consistent with the purpose and scope.
+* E-mail discussions on the working group mailing list, working group conference
+calls, and face-to-face meetings from time to time.
 
-# Background information
-## Related work:
-* [RFC4120](https://tools.ietf.org/html/rfc4120) – The Kerberos Network Authentication Service (V5)
-* [RFC6545](https://tools.ietf.org/html/rfc6545) – Real-time Inter-network Defense (RID)
-* [RFC6546](https://tools.ietf.org/html/rfc6546) – Transport of Real-time Inter-network Defense (RID) Messages over HTTP/TLS
-* [RFC6684](https://tools.ietf.org/html/rfc6684) – Guidelines and Template for Defining Extensions to the Incident Object Description Exchange Format (IODEF)
-* [RFC6960](https://tools.ietf.org/html/rfc6960) – Online Certificate Status Protocol (OCSP)
-* [RFC7642](https://tools.ietf.org/html/rfc7642), [7643](https://tools.ietf.org/html/rfc7643), [7644](https://tools.ietf.org/html/rfc7644) – System for Cross-domain Identity Management (SCIM)
-* [RFC8322](https://tools.ietf.org/html/rfc8322) – Resource-Oriented Lightweight Indicator Exchange
+## 8) Basis for determining when the work is completed
+
+* Rough consensus and running code. The work will be completed once it is
+apparent that maximal consensus on the draft has been achieved, consistent with
+the purpose and scope.
+
+## Background information
+
+### Related work
+
+* [RFC4120](https://tools.ietf.org/html/rfc4120) – The Kerberos Network
+Authentication Service (V5)
+* [RFC6545](https://tools.ietf.org/html/rfc6545) – Real-time Inter-network
+Defense (RID)
+* [RFC6546](https://tools.ietf.org/html/rfc6546) – Transport of Real-time
+Inter-network Defense (RID) Messages over HTTP/TLS
+* [RFC6684](https://tools.ietf.org/html/rfc6684) – Guidelines and Template for
+Defining Extensions to the Incident Object Description Exchange Format (IODEF)
+* [RFC6960](https://tools.ietf.org/html/rfc6960) – Online Certificate Status
+Protocol (OCSP)
+* [RFC7642](https://tools.ietf.org/html/rfc7642),
+[7643](https://tools.ietf.org/html/rfc7643),
+[7644](https://tools.ietf.org/html/rfc7644) – System for Cross-domain Identity
+Management (SCIM)
+* [RFC8322](https://tools.ietf.org/html/rfc8322) – Resource-Oriented Lightweight
+Indicator Exchange
 * [RFC8417](https://tools.ietf.org/html/rfc8417) – Security Event Token (SET)
-* [draft-hunt-scim-notify](https://tools.ietf.org/html/draft-hunt-scim-notify) – SCIM Notify
-* [draft-ietf-secevent-http-poll](https://tools.ietf.org/html/draft-ietf-secevent-http-poll) – Poll-based Security Event Token (SET) Delivery Using HTTP
-* [draft-ietf-secevent-http-push](https://tools.ietf.org/html/draft-ietf-secevent-http-push) – Push-based Security Event Token (SET) Delivery Using HTTP
-* [draft-ietf-secevent-subject-identifiers](https://tools.ietf.org/html/draft-ietf-secevent-subject-identifiers) – Subject Identifiers for Security Event Tokens
-* [ISO/IEC 27002:2013](https://www.iso.org/standard/54533.html)  – Information technology — Security techniques — Code of practice for information security controls
-* [ISO/IEC 27035:2011](https://www.iso.org/standard/44379.html) – Information technology — Security techniques — Information security incident management
-* [sstc-saml-core-2.0-os](http://saml.xml.org/saml-specifications) - Security Assertion Markup Language (SAML) 2.0
-* [ws-trust-1.3-spec-os](http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html) – WS-Trust
-* [XACML-v3.0-Errata01](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=xacml) – eXtensible Access Control Markup Language (XACML)
+* [draft-hunt-scim-notify](https://tools.ietf.org/html/draft-hunt-scim-notify) –
+SCIM Notify
+* [RFC8936](https://tools.ietf.org/html/rfc8936) – Poll-based Security Event
+Token (SET) Delivery Using HTTP
+* [RFC8935](https://tools.ietf.org/html/rfc8935) – Push-based Security Event
+Token (SET) Delivery Using HTTP
+* [RFC9493](https://tools.ietf.org/html/rfc9493) – Subject Identifiers for
+Security Event Tokens
+* [ISO/IEC 27002:2013](https://www.iso.org/standard/54533.html)  – Information
+technology — Security techniques — Code of practice for information security
+controls
+* [ISO/IEC 27035:2011](https://www.iso.org/standard/44379.html) – Information
+technology — Security techniques — Information security incident management
+* [sstc-saml-core-2.0-os](http://saml.xml.org/saml-specifications) - Security
+Assertion Markup Language (SAML) 2.0
+* [ws-trust-1.3-spec-os](http://docs.oasis-open.org/ws-sx/ws-trust/200512/ws-trust-1.3-os.html)
+– WS-Trust
+* [XACML-v3.0-Errata01](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=xacml)
+– eXtensible
+Access Control Markup Language (XACML)
 
-## Proposers
-### 2019 Re-charter as Shared Signals Working Group
+### Proposers
+
+#### 2019 Re-charter as Shared Signals Working Group
+
 * Asad Ali, Thales
 * Morteza Ansari, Cisco
 * Annabelle Backman, Amazon
@@ -106,7 +192,8 @@ The group will work to produce the Security Event and Account Lifecycle Schema b
 * Jordan Wright, Cisco
 * Reda Zerrad, Lookout
 
-### Original RISC Working Group
+#### Original RISC Working Group
+
 * Henrik Biering, Peercraft
 * John Bradley, Ping Identity
 * Adam Dawes, Google
@@ -117,9 +204,15 @@ The group will work to produce the Security Event and Account Lifecycle Schema b
 * Vicente Silveira, LinkedIn
 * Alex Weinert, Microsoft
 
-## Anticipated contributions:
-* "CAEP Event Types 1.0" under the [OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
-* "OAuth Event Types 1.0" under the [OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
-* "OpenID RISC Event Types 1.0" under the [OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
-* "OpenID RISC Profile of IETF Security Events 1.0" under the [OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
-* "Security Event Token (SET) Stream Management API" under the [OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
+### Anticipated contributions
+
+* "CAEP Event Types 1.0" under the
+[OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
+* "OAuth Event Types 1.0" under the
+[OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
+* "OpenID RISC Event Types 1.0" under the
+[OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
+* "OpenID RISC Profile of IETF Security Events 1.0" under the
+[OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).
+* "Security Event Token (SET) Stream Management API" under the
+[OpenID Foundation’s IPR Policy](http://openid.net/intellectual-property/).


### PR DESCRIPTION
Using a markdown linter (https://github.com/DavidAnson/markdownlint/tree/v0.37.4), i cleaned up our markdown files. all has been tested running the `make` command.

I overwrote some of the default linter settings in `.markdownlint.yaml` that didn't align with kramdown-rfc/xml2rfc generators

I cleaned up the markdown for the following files:
- openid-caep-1_0.md
- openid-caep-interoperability-profile-1_0.md
- openid-sharedsignals-framework-1_0.md
- working-group-charter.md

I also opened #264 to update RISC to use md as source of truth rather than xml for easier maintenance