### PR TITLE
Generic Language for prescriptive SETs - Issue 255

### DIFF
--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -484,7 +484,7 @@ on this subject. The Shared Signals Framework requires further restrictions:
 The signature key can be obtained through "jwks_uri", see {{discovery}}.
 
 ### SSF Prescriptive SETs {#prescriptive-sets}
-The Shared Signals Framework allows each deployment or integration to define its own event processing behaviors, ranging from informational input to additional processing needed, to mandatory enforcement (e.g., session revoke). See {{caep-event-prescriptive-example}}.
+The Shared Signals Framework allows each deployment or integration to define its own event processing behaviors, ranging from informational input to additional processing needed, to mandatory enforcement.
 
 ### The "iss" Claim {#iss-claim}
 The "iss" claim MUST match the "iss" value in the Stream Configuration data for the stream
@@ -696,27 +696,6 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
 }
 ~~~
 {: #subject-custom-type-ex title="Example: SET Containing an SSF Event with a Proprietary Subject Identifier Format"}
-
-~~~ json
-{
-  "iss": "https://idp.example.com/",
-  "jti": "756E69717565206964656E746966696572",
-  "iat": 1520364019,
-  "txn": 8675309,
-  "aud": "636C69656E745F6964",
-  "sub_id": {
-    "format": "phone_number",
-    "phone_number": "+1 813 867 5309"
-  },
-  "events": {
-    "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {}
-  },
-  "actions": {
-    "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {}
-  }
-}
-~~~
-{: #caep-event-prescriptive-example title="Example: SET Containing a prescriptive SSF Event that will inform the receiver of the expected action to be performed"}
 
 # Event Delivery {#event-delivery}
 This section describes the supported methods of delivering SSF Events. It provides SSF profiling specifications for the {{RFC8935}} and {{RFC8936}} specs.

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -483,6 +483,9 @@ on this subject. The Shared Signals Framework requires further restrictions:
 ### Signature Key Resolution {#signature-key-resolution}
 The signature key can be obtained through "jwks_uri", see {{discovery}}.
 
+### SSF Prescriptive SETs {#prescriptive-sets}
+The Shared Signals Framework allows each deployment or integration to define its own event processing behaviors, ranging from informational input to additional processing needed, to mandatory enforcement (e.g., session revoke). See {{caep-event-prescriptive-example}}.
+
 ### The "iss" Claim {#iss-claim}
 The "iss" claim MUST match the "iss" value in the Stream Configuration data for the stream
 that the event is sent on. Receivers MUST validate that this claim matches the "iss"
@@ -693,6 +696,27 @@ The following are hypothetical examples of SETs that conform to the Shared Signa
 }
 ~~~
 {: #subject-custom-type-ex title="Example: SET Containing an SSF Event with a Proprietary Subject Identifier Format"}
+
+~~~ json
+{
+  "iss": "https://idp.example.com/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1520364019,
+  "txn": 8675309,
+  "aud": "636C69656E745F6964",
+  "sub_id": {
+    "format": "phone_number",
+    "phone_number": "+1 813 867 5309"
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {}
+  },
+  "actions": {
+    "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {}
+  }
+}
+~~~
+{: #caep-event-prescriptive-example title="Example: SET Containing a prescriptive SSF Event that will inform the receiver of the expected action to be performed"}
 
 # Event Delivery {#event-delivery}
 This section describes the supported methods of delivering SSF Events. It provides SSF profiling specifications for the {{RFC8935}} and {{RFC8936}} specs.


### PR DESCRIPTION
In reference to [Issue 255](https://github.com/openid/sharedsignals/issues/255) marked for v1 Final per the discussion last week in the SSWG Call. 

I added a sub section under Section 4 called "SSF Prescriptive SETs" and an example figure of what a prescriptive SET may look like under Section 5.

Open to feedback on the example. I took the IPSIE action out as defined [here](https://github.com/openid/ipsie/issues/66) and replaced it with a duplicative `session-revoked` event to convey that the transmitter is expecting the action to be taken is to revoke a session even though the SET is referencing the same event. I am all for using an IPSIE profile in there to convey cross standard usage of SSF but wanted to get some feedback from the reviewers. 

I thought Section 4 was a decent place to call out that the Events in a SET can be treated as prescriptive. For those following along I will add the text here for brevity. I tried to keep it clean and concise and added a new section called **SSF Prescriptive SETs**. See below:
```The Shared Signals Framework allows each deployment or integration to define its own event processing behaviors, ranging from informational input to additional processing needed, to mandatory enforcement (e.g., session revoke). See {{Referenced Example I created in Section 5}}.``` 