### PR TITLE
Prepare specs for CAEP draft 5, RISC draft 3, and SSF draft 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .refcache
 *.xpr
 scratch.md
+openid-caep-1_0.xml
+openid-sharedsignals-framework-1_0.xml

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ all:
 	@ make openid-caep-1_0.txt
 
 propose:
-	@ cp openid-sharedsignals-framework-1_0.xml ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.xml
+	@ cp openid-sharedsignals-framework-1_0.txt ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.txt
 	@ cp openid-sharedsignals-framework-1_0.html ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.html
 	@ cp openid-sharedsignals-framework-1_0.md ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.md
 	@ cp openid-risc-1_0.html ../publication/sharedsignals/openid-risc-1_0-03.html
 	@ cp openid-risc-1_0.xml ../publication/sharedsignals/openid-risc-1_0-03.xml
 	@ cp openid-risc-1_0.txt ../publication/sharedsignals/openid-risc-1_0-03.txt
-	@ cp openid-caep-1_0.xml ../publication/sharedsignals/openid-caep-1_0-05.xml
+	@ cp openid-caep-1_0.txt ../publication/sharedsignals/openid-caep-1_0-05.txt
 	@ cp openid-caep-1_0.html ../publication/sharedsignals/openid-caep-1_0-05.html
 	@ cp openid-caep-1_0.md ../publication/sharedsignals/openid-caep-1_0-05.md

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,13 @@ html:   $(HTML)
 
 %.xml: %.md
 	kramdown-rfc2629 > $@ $^
+
+all:
+	@ make openid-sharedsignals-framework-1_0.xml
+	@ make openid-sharedsignals-framework-1_0.html
+	@ make openid-sharedsignals-framework-1_0.txt
+	@ make openid-risc-1_0.html
+	@ make openid-risc-1_0.txt
+	@ make openid-caep-1_0.xml
+	@ make openid-caep-1_0.html
+	@ make openid-caep-1_0.txt

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,14 @@ all:
 	@ make openid-caep-1_0.xml
 	@ make openid-caep-1_0.html
 	@ make openid-caep-1_0.txt
+
+propose:
+	@ cp openid-sharedsignals-framework-1_0.xml ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.xml
+	@ cp openid-sharedsignals-framework-1_0.html ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.html
+	@ cp openid-sharedsignals-framework-1_0.md ../publication/sharedsignals/openid-sharedsignals-framework-1_0-05.md
+	@ cp openid-risc-1_0.html ../publication/sharedsignals/openid-risc-1_0-03.html
+	@ cp openid-risc-1_0.xml ../publication/sharedsignals/openid-risc-1_0-03.xml
+	@ cp openid-risc-1_0.txt ../publication/sharedsignals/openid-risc-1_0-03.txt
+	@ cp openid-caep-1_0.xml ../publication/sharedsignals/openid-caep-1_0-05.xml
+	@ cp openid-caep-1_0.html ../publication/sharedsignals/openid-caep-1_0-05.html
+	@ cp openid-caep-1_0.md ../publication/sharedsignals/openid-caep-1_0-05.md

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -3,7 +3,7 @@ title: OpenID Continuous Access Evaluation Profile 1.0 - draft 05
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-07-31
+date: 2025-07-30
 
 ipr: none
 cat: std
@@ -996,7 +996,7 @@ specification.
 
 # Notices
 
-Copyright (c) 2024 The OpenID Foundation.
+Copyright (c) 2025 The OpenID Foundation.
 
 The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
 or other interested party a non-exclusive, royalty free, worldwide copyright

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -999,33 +999,33 @@ specification.
 Copyright (c) 2025 The OpenID Foundation.
 
 The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
-or other interested party a non-exclusive, royalty free, worldwide copyright
-license to reproduce, prepare derivative works from, distribute, perform and
-display, this Implementers Draft or Final Specification solely for the purposes
-of (i) developing specifications, and (ii) implementing Implementers Drafts and
-Final Specifications based on such documents, provided that attribution be made
-to the OIDF as the source of the material, but that such attribution does not
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
 indicate an endorsement by the OIDF.
 
-The technology described in this specification was made available from
-contributions from various sources, including members of the OpenID Foundation
-and others. Although the OpenID Foundation has taken steps to help ensure that
-the technology is available for distribution, it takes no position regarding the
-validity or scope of any intellectual property or other rights that might be
-claimed to pertain to the implementation or use of the technology described in
-this specification or the extent to which any license under such rights might or
-might not be available; neither does it represent that it has made any
-independent effort to identify any such rights. The OpenID Foundation and the
-contributors to this specification make no (and hereby expressly disclaim any)
-warranties (express, implied, or otherwise), including implied warranties of
-merchantability, non-infringement, fitness for a particular purpose, or title,
-related to this specification, and the entire risk as to implementing this
+The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
 specification is assumed by the implementer. The OpenID Intellectual Property
-Rights policy requires contributors to offer a patent promise not to assert
-certain patent claims against other contributors and against implementers. The
-OpenID Foundation invites any interested party to bring to its attention any
-copyrights, patents, patent applications, or other proprietary rights that may
-cover technology that may be required to practice this specification.
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.
 
 # Document History
 

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -1,9 +1,9 @@
 ---
-title: OpenID Continuous Access Evaluation Profile 1.0 - draft 12
+title: OpenID Continuous Access Evaluation Profile 1.0 - draft 05
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-05-29
+date: 2025-07-31
 
 ipr: none
 cat: std

--- a/openid-risc-1_0.xml
+++ b/openid-risc-1_0.xml
@@ -63,7 +63,7 @@
       </address>
     </author>
 
-    <date year="2025" month="July" day="31"/>
+    <date year="2025" month="July" day="30"/>
 
     <workgroup>Shared Signals</workgroup>
 
@@ -539,7 +539,7 @@
         specification.</t>
     </section>
     <section anchor="Notices" title="Notices">
-      <t>Copyright (c) 2022 The OpenID Foundation.</t>
+      <t>Copyright (c) 2025 The OpenID Foundation.</t>
       <t>
 	The OpenID Foundation (OIDF) grants to any Contributor, developer,
 	implementer, or other interested party a non-exclusive, royalty free,

--- a/openid-risc-1_0.xml
+++ b/openid-risc-1_0.xml
@@ -418,6 +418,14 @@
           implementation to conform to this specification.</t>
       </section>
    </section>
+    <section anchor="security" title="Security Considerations">
+      <t>
+        Any implementations of events described in this document SHOULD comply with the
+        <xref target="SHARED-SIGNALS-FRAMEWORK">Shared Signals Framework</xref>.
+        Exchanging events described herein without complying with the
+        <xref target="SHARED-SIGNALS-FRAMEWORK">Shared Signals Framework</xref>
+        may result in security issues.</t>
+   </section>
   </middle>
 
   <back>

--- a/openid-risc-1_0.xml
+++ b/openid-risc-1_0.xml
@@ -24,7 +24,7 @@
   <?rfc comments="yes"?>
 
   <front>
-    <title abbrev="openid-risc-profile-specification">OpenID RISC Profile Specification 1.0 - draft 04</title>
+    <title abbrev="openid-risc-profile-specification">OpenID RISC Profile Specification 1.0 - draft 03</title>
 
     <author initials="M." surname="Scurtescu" fullname="Marius Scurtescu">
       <organization abbrev="Coinbase">Coinbase</organization>
@@ -63,7 +63,7 @@
       </address>
     </author>
 
-    <date year="2025" month="May" day="13"/>
+    <date year="2025" month="July" day="31"/>
 
     <workgroup>Shared Signals</workgroup>
 

--- a/openid-risc-1_0.xml
+++ b/openid-risc-1_0.xml
@@ -541,42 +541,35 @@
     <section anchor="Notices" title="Notices">
       <t>Copyright (c) 2025 The OpenID Foundation.</t>
       <t>
-	The OpenID Foundation (OIDF) grants to any Contributor, developer,
-	implementer, or other interested party a non-exclusive, royalty free,
-	worldwide copyright license to reproduce, prepare derivative works from,
-	distribute, perform and display, this Implementers Draft or
-	Final Specification solely for the purposes of (i) developing
-	specifications, and (ii) implementing Implementers Drafts and
-	Final Specifications based on such documents, provided that attribution
-	be made to the OIDF as the source of the material, but that such attribution
-	does not indicate an endorsement by the OIDF.
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
       </t>
       <t>
-	The technology described in this specification was
-	made available from contributions from various sources,
-	including members of the OpenID Foundation and others.
-	Although the OpenID Foundation has taken steps to help ensure
-	that the technology is available for distribution, it takes
-	no position regarding the validity or scope of any intellectual
-	property or other rights that might be claimed to pertain to
-	the implementation or use of the technology described in
-	this specification or the extent to which any license under
-	such rights might or might not be available; neither does it
-	represent that it has made any independent effort to identify
-	any such rights.  The OpenID Foundation and the contributors
-	to this specification make no (and hereby expressly disclaim any)
-	warranties (express, implied, or otherwise), including implied
-	warranties of merchantability, non-infringement, fitness for
-	a particular purpose, or title, related to this specification,
-	and the entire risk as to implementing this specification is
-	assumed by the implementer.  The OpenID Intellectual
-	Property Rights policy requires contributors to offer
-	a patent promise not to assert certain patent claims against
-	other contributors and against implementers.  The OpenID Foundation invites
-	any interested party to bring to its attention any copyrights,
-	patents, patent applications, or other proprietary rights
-	that may cover technology that may be required to practice
-	this specification.
+The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.
       </t>
     </section>
     <section anchor="History" title="Document History">

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -2528,33 +2528,33 @@ specification.
 Copyright (c) 2025 The OpenID Foundation.
 
 The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
-or other interested party a non-exclusive, royalty free, worldwide copyright
-license to reproduce, prepare derivative works from, distribute, perform and
-display, this Implementers Draft or Final Specification solely for the purposes
-of (i) developing specifications, and (ii) implementing Implementers Drafts and
-Final Specifications based on such documents, provided that attribution be made
-to the OIDF as the source of the material, but that such attribution does not
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
 indicate an endorsement by the OIDF.
 
-The technology described in this specification was made available from
-contributions from various sources, including members of the OpenID Foundation
-and others. Although the OpenID Foundation has taken steps to help ensure that
-the technology is available for distribution, it takes no position regarding the
- validity or scope of any intellectual property or other rights that might be
- claimed to pertain to the implementation or use of the technology described in
- this specification or the extent to which any license under such rights might
- or might not be available; neither does it represent that it has made any
- independent effort to identify any such rights. The OpenID Foundation and the
- contributors to this specification make no (and hereby expressly disclaim any)
- warranties (express, implied, or otherwise), including implied warranties of
- merchantability, non-infringement, fitness for a particular purpose, or title,
- related to this specification, and the entire risk as to implementing this
- specification is assumed by the implementer. The OpenID Intellectual Property
- Rights policy requires contributors to offer a patent promise not to assert
- certain patent claims against other contributors and against implementers. The
- OpenID Foundation invites any interested party to bring to its attention any
- copyrights, patents, patent applications, or other proprietary rights that may
- cover technology that may be required to practice this specification.
+The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.
 
 # Document History
 

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -2,7 +2,7 @@
 title: OpenID Shared Signals Framework Specification 1.0 - draft 05
 abbrev: SharedSignals
 docname: openid-sharedsignals-framework-1_0
-date: 2025-07-31
+date: 2025-07-30
 
 ipr: none
 cat: std
@@ -2525,7 +2525,7 @@ specification.
 
 # Notices
 
-Copyright (c) 2024 The OpenID Foundation.
+Copyright (c) 2025 The OpenID Foundation.
 
 The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
 or other interested party a non-exclusive, royalty free, worldwide copyright

--- a/openid-sharedsignals-framework-1_0.md
+++ b/openid-sharedsignals-framework-1_0.md
@@ -1,8 +1,8 @@
 ---
-title: OpenID Shared Signals Framework Specification 1.0 - draft 24
+title: OpenID Shared Signals Framework Specification 1.0 - draft 05
 abbrev: SharedSignals
 docname: openid-sharedsignals-framework-1_0
-date: 2025-06-23
+date: 2025-07-31
 
 ipr: none
 cat: std


### PR DESCRIPTION
We want this round of implementer's draft to become the final v1. We have added a few non-normative changes during the review period for draft 4 (typo fixes and examples) that we would like to have included in that v1. Mike Jones has suggested that we publish a draft 5 and make it part of the current vote instead of trying to restart the process. There is precedent for this action.