### PR TITLE
Add an option to report device management status change to device compliance change signal

### DIFF
--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -737,7 +737,7 @@ be one of the following strings:
 >
 > * `compliant`
 > * `not-compliant`
-> * `unmanaged`: The device is no loner being managed and additional compliance change events may not be sent for this device. The device compliance state is unknown
+> * `unmanaged`: The device is no longer being managed, and additional compliance change events may not be sent for this device. The device’s compliance state is unknown
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the device compliance status changed.

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -37,6 +37,13 @@ contributor:
         contribution: |
           Apoorva defined the `risk-level-change` event.
 
+contributor:
+      -
+        ins: Y. Sarig
+        name: Yair Sarig
+        org: Omnissa
+        email: ysarig@omnissa.com
+
 normative:
   ISO-IEC-29115:
     target: https://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=45138
@@ -730,6 +737,7 @@ be one of the following strings:
 >
 > * `compliant`
 > * `not-compliant`
+> * `unmanaged`: The device is no loner being managed and additional compliance change events may not be sent for this device. The device compliance state is unknown
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the device compliance status changed.

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -729,6 +729,7 @@ triggered the event. This MUST be one of the following strings:
 >
 > * `compliant`
 > * `not-compliant`
+> * `unknown`
 
 current_status
 

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -36,8 +36,6 @@ contributor:
         email: apoorva.deshpande@okta.com
         contribution: |
           Apoorva defined the `risk-level-change` event.
-
-contributor:
       -
         ins: Y. Sarig
         name: Yair Sarig

--- a/openid-caep-1_0.md
+++ b/openid-caep-1_0.md
@@ -1,9 +1,8 @@
 ---
-title: OpenID Continuous Access Evaluation Profile 1.0
+title: OpenID Continuous Access Evaluation Profile 1.1
 
 abbrev: CAEP-Spec
 docname: openid-caep-1_0
-date: 2025-08-29
 
 ipr: none
 cat: std
@@ -712,7 +711,7 @@ Event Type URI:
 
 `https://schemas.openid.net/secevent/caep/event-type/device-compliance-change`
 
-Device Compliance Change signals that a device's compliance status has changed.
+Device Compliance Change signals that a device's compliance or managed status has changed.
 
 The actual reason why the status change occurred might be specified with the
 nested `reason_admin` and/or `reason_user` claims made in
@@ -720,23 +719,31 @@ nested `reason_admin` and/or `reason_user` claims made in
 
 ### Event-Specific Claims {#device-compliance-change-claims}
 
+The transmitter MUST send at least one of the current_status or current_management_status claims.
+
 previous_status
 
-> REQUIRED, JSON string: the compliance status prior to the change that
+> OPTIONAL, JSON string: the compliance status prior to the change that
 triggered the event. This MUST be one of the following strings:
 >
 > * `compliant`
 > * `not-compliant`
-> * `unknown`
 
 current_status
 
-> REQUIRED, JSON string: the current status that triggered the event. This MUST
+> OPTIONAL, JSON string: the current status that triggered the event. This MUST
 be one of the following strings:
 >
 > * `compliant`
 > * `not-compliant`
-> * `unmanaged`: The device is no longer being managed, and additional compliance change events may not be sent for this device. The device’s compliance state is unknown
+
+ current_management_status
+
+> OPTIONAL, JSON string: the current management status that triggered the event. This MUST
+be one of the following strings:
+>
+> * `managed`
+> * `not-managed`
 
 When `event_timestamp` is included, its value MUST represent the time at which
 the device compliance status changed.


### PR DESCRIPTION
Add an 'unmanaged' option to current_status in device compliance change event.